### PR TITLE
Hex paste validation - trim whitespace chars

### DIFF
--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -298,7 +298,7 @@ class HexadecimalViewController: UIViewController {
         
         //Validate input is a hexadecimal value
         let chars = CharacterSet(charactersIn: "0123456789ABCDEF").inverted
-        let isValidHexadecimal = pastedInput.uppercased().rangeOfCharacter(from: chars) == nil
+        let isValidHexadecimal = pastedInput.trimmingCharacters(in: .whitespaces).uppercased().rangeOfCharacter(from: chars) == nil
         if (isValidHexadecimal && pastedInput.count <= 16) {
             if (pastedInput == "0") {
                 runningNumber = ""


### PR DESCRIPTION
This PR is meant to trim whitespace from pasted string for hex input 

I copied / pasted a string of hex characters with spaces in between from safari 
`47 49`

when I paste in HexaCalc, it shows an error dialog "Paste Failed"
your clipboard does not contain a valid hexadecimal string. 

I'm not a swift dev, I followed the examples on https://stackoverflow.com/questions/26797739/does-swift-have-a-trim-method-on-string 

thanks for making this app, especially free , open source, and no ads. 