### PR TITLE
Fix typo: currentContraints -> currentConstraints across all VCs

### DIFF
--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -55,7 +55,7 @@ class BinaryViewController: UIViewController {
     var currentOperation:Operation = .NULL
     
     // Current contraints are stored for the iPad such that rotating the screen allows constraints to be replaced
-    var currentContraints: [NSLayoutConstraint] = []
+    var currentConstraints: [NSLayoutConstraint] = []
     
     var currentlyRecognizingDoubleTap = false
     
@@ -110,15 +110,15 @@ class BinaryViewController: UIViewController {
         
         if (UIDevice.current.userInterfaceIdiom == .pad) {
             let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: binVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
-            currentContraints.append(contentsOf: stackConstraints)
+            currentConstraints.append(contentsOf: stackConstraints)
             
             let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
-            currentContraints.append(contentsOf: buttonConstraints)
+            currentConstraints.append(contentsOf: buttonConstraints)
             
             let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
-            currentContraints.append(contentsOf: labelConstraints)
+            currentConstraints.append(contentsOf: labelConstraints)
             
-            NSLayoutConstraint.activate(currentContraints)
+            NSLayoutConstraint.activate(currentConstraints)
         }
         else {
             let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: binVStack, outputLabel: outputLabel, screenWidth: screenWidth)
@@ -226,8 +226,8 @@ class BinaryViewController: UIViewController {
         
         // Deactivate current contraints and remove them from the list, new constraints will be calculated and activated as device rotates
         if (UIDevice.current.userInterfaceIdiom == .pad) {
-            NSLayoutConstraint.deactivate(currentContraints)
-            currentContraints.removeAll()
+            NSLayoutConstraint.deactivate(currentConstraints)
+            currentConstraints.removeAll()
         }
     }
     

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -51,7 +51,7 @@ class DecimalViewController: UIViewController {
     var currentOperation: Operation = .NULL
     
     // Current contraints are stored for the iPad such that rotating the screen allows constraints to be replaced
-    var currentContraints: [NSLayoutConstraint] = []
+    var currentConstraints: [NSLayoutConstraint] = []
     
     var currentlyRecognizingDoubleTap = false
     
@@ -101,15 +101,15 @@ class DecimalViewController: UIViewController {
         
         if (UIDevice.current.userInterfaceIdiom == .pad) {
             let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: decVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
-            currentContraints.append(contentsOf: stackConstraints)
+            currentConstraints.append(contentsOf: stackConstraints)
             
             let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
-            currentContraints.append(contentsOf: buttonConstraints)
+            currentConstraints.append(contentsOf: buttonConstraints)
             
             let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
-            currentContraints.append(contentsOf: labelConstraints)
+            currentConstraints.append(contentsOf: labelConstraints)
             
-            NSLayoutConstraint.activate(currentContraints)
+            NSLayoutConstraint.activate(currentConstraints)
         }
         else {
             let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: decVStack, outputLabel: outputLabel, screenWidth: screenWidth)
@@ -220,8 +220,8 @@ class DecimalViewController: UIViewController {
         
         // Deactivate current contraints and remove them from the list, new constraints will be calculated and activated as device rotates
         if (UIDevice.current.userInterfaceIdiom == .pad) {
-            NSLayoutConstraint.deactivate(currentContraints)
-            currentContraints.removeAll()
+            NSLayoutConstraint.deactivate(currentConstraints)
+            currentConstraints.removeAll()
         }
     }
     

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -67,7 +67,7 @@ class HexadecimalViewController: UIViewController {
     var currentOperation:Operation = .NULL
     
     // Current contraints are stored for the iPad such that rotating the screen allows constraints to be replaced
-    var currentContraints: [NSLayoutConstraint] = []
+    var currentConstraints: [NSLayoutConstraint] = []
     
     var currentlyRecognizingDoubleTap = false
     
@@ -183,15 +183,15 @@ class HexadecimalViewController: UIViewController {
         
         if (UIDevice.current.userInterfaceIdiom == .pad) {
             let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: hexVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
-            currentContraints.append(contentsOf: stackConstraints)
+            currentConstraints.append(contentsOf: stackConstraints)
             
             let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
-            currentContraints.append(contentsOf: buttonConstraints)
+            currentConstraints.append(contentsOf: buttonConstraints)
             
             let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
-            currentContraints.append(contentsOf: labelConstraints)
+            currentConstraints.append(contentsOf: labelConstraints)
             
-            NSLayoutConstraint.activate(currentContraints)
+            NSLayoutConstraint.activate(currentConstraints)
         }
         else {
             let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: hexVStack, outputLabel: outputLabel, screenWidth: screenWidth)
@@ -304,8 +304,8 @@ class HexadecimalViewController: UIViewController {
         
         // Deactivate current contraints and remove them from the list, new constraints will be calculated and activated as device rotates
         if (UIDevice.current.userInterfaceIdiom == .pad) {
-            NSLayoutConstraint.deactivate(currentContraints)
-            currentContraints.removeAll()
+            NSLayoutConstraint.deactivate(currentConstraints)
+            currentConstraints.removeAll()
         }
     }
     


### PR DESCRIPTION
Corrects the spelling of the currentConstraints property in BinaryViewController, DecimalViewController, and HexadecimalViewController. No functional changes.