### PR TITLE
Refactor: extract CalculatorViewController base class to reduce duplicated code

### DIFF
--- a/HexaCalc.xcodeproj/project.pbxproj
+++ b/HexaCalc.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		9DAE268A24C68BEB0070B965 /* RoundButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAE268924C68BEB0070B965 /* RoundButton.swift */; };
 		9DAE268D24C68C300070B965 /* Formatter+ScientificNotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAE268C24C68C300070B965 /* Formatter+ScientificNotation.swift */; };
 		9DAE269524C7F77A0070B965 /* StateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAE269424C7F77A0070B965 /* StateController.swift */; };
+		8DC73473DF154A1AB56A8AD4 /* CalculatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A663F08D8745E2B3469E80 /* CalculatorViewController.swift */; };
 		9DC1BDD22F90ACC3003D5CB5 /* HistoryButtonHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC1BDD12F90ACC3003D5CB5 /* HistoryButtonHost.swift */; };
 		9DC242F225E1EE440038DD63 /* UIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC242F125E1EE440038DD63 /* UIHelper.swift */; };
 		9DC4DA182944367500D1652E /* BinaryHexaCalcUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4DA172944367500D1652E /* BinaryHexaCalcUITests.swift */; };
@@ -128,6 +129,7 @@
 		9DAE268924C68BEB0070B965 /* RoundButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundButton.swift; sourceTree = "<group>"; };
 		9DAE268C24C68C300070B965 /* Formatter+ScientificNotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Formatter+ScientificNotation.swift"; sourceTree = "<group>"; };
 		9DAE269424C7F77A0070B965 /* StateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateController.swift; sourceTree = "<group>"; };
+		E8A663F08D8745E2B3469E80 /* CalculatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorViewController.swift; sourceTree = "<group>"; };
 		9DC1BDD12F90ACC3003D5CB5 /* HistoryButtonHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryButtonHost.swift; sourceTree = "<group>"; };
 		9DC242F125E1EE440038DD63 /* UIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIHelper.swift; sourceTree = "<group>"; };
 		9DC4DA172944367500D1652E /* BinaryHexaCalcUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryHexaCalcUITests.swift; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 		9D6DE93024D3CCD4005018E5 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				E8A663F08D8745E2B3469E80 /* CalculatorViewController.swift */,
 				9DEF249A24C553F000701F5B /* HexadecimalViewController.swift */,
 				9DEF249C24C553F000701F5B /* BinaryViewController.swift */,
 				9DEF24BD24C5578300701F5B /* DecimalViewController.swift */,
@@ -627,6 +630,7 @@
 				9DC758292803C85200BB2953 /* SelectionSummaryTableViewCell.swift in Sources */,
 				9DEF249924C553F000701F5B /* SceneDelegate.swift in Sources */,
 				C272D50A28E75D7C00E6C374 /* CalculationData.swift in Sources */,
+				8DC73473DF154A1AB56A8AD4 /* CalculatorViewController.swift in Sources */,
 				9DC1BDD22F90ACC3003D5CB5 /* HistoryButtonHost.swift in Sources */,
 				9DC242F225E1EE440038DD63 /* UIHelper.swift in Sources */,
 			);

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -8,21 +8,18 @@
 
 import UIKit
 
-class BinaryViewController: UIViewController, HistoryButtonHost {
-    
+class BinaryViewController: CalculatorViewController {
+
     //MARK: Properties
-    var stateController: StateController?
-    
-    let binaryDefaultLabel:String = "0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"
-    
-    @IBOutlet weak var outputLabel: UILabel!
+    let binaryDefaultLabel: String = "0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"
+
     @IBOutlet weak var binVStack: UIStackView!
     @IBOutlet weak var binHStack1: UIStackView!
     @IBOutlet weak var binHStack2: UIStackView!
     @IBOutlet weak var binHStack3: UIStackView!
     @IBOutlet weak var binHStack4: UIStackView!
     @IBOutlet weak var binHStack5: UIStackView!
-    
+
     @IBOutlet weak var ACBtn: RoundButton!
     @IBOutlet weak var DELBtn: RoundButton!
     @IBOutlet weak var DIVBtn: RoundButton!
@@ -42,96 +39,105 @@ class BinaryViewController: UIViewController, HistoryButtonHost {
     @IBOutlet weak var EQUALSBtn: RoundButton!
     @IBOutlet weak var Btn00: RoundButton!
     @IBOutlet weak var Btn11: RoundButton!
-    
-    // Programmatic UIButton
-    var historyButton: UIButton!
-    var historyButtonWidthConstraint: NSLayoutConstraint?
-    
+
     //MARK: Variables
-    var runningNumber = ""
-    var leftValue = ""
-    var rightValue = ""
     var leftBinValue = ""
     var rightBinValue = ""
-    var result = ""
-    var currentOperation:Operation = .NULL
-    
-    // Current contraints are stored for the iPad such that rotating the screen allows constraints to be replaced
-    var currentConstraints: [NSLayoutConstraint] = []
-    
-    var currentlyRecognizingDoubleTap = false
-    
-    var calculationHistory: [CalculationData] = []
-    
-    // Access singleton TelemetryManager class object
-    let telemetryManager = TelemetryManager.sharedTelemetryManager
-    let telemetryTab = TelemetryTab.Binary
-    
+
+    // MARK: Abstract overrides
+
+    override var telemetryTab: TelemetryTab { .Binary }
+    override var historyFlagReadMask: Int32 { 2 }
+    override var historyFlagShift: Int32 { 1 }
+    override var historyFlagClearMask: Int32 { 5 }
+
+    override func deleteLastDigit() {
+        deletePressed(DELBtn)
+    }
+
+    override func pasteFromClipboard() {
+        pasteFromClipboardToBinaryCalculator()
+    }
+
+    override func copyTextFromLabel() -> String {
+        if runningNumber == "" {
+            var currentOutput = outputLabel.text ?? binaryDefaultLabel
+            currentOutput = currentOutput.replacingOccurrences(of: " ", with: "")
+            var end = false
+            for char in currentOutput {
+                if char == "0" && !end {
+                    currentOutput.remove(at: currentOutput.startIndex)
+                }
+                else {
+                    end = true
+                }
+            }
+            return currentOutput.isEmpty ? "0" : currentOutput
+        }
+        return runningNumber
+    }
+
+    override func updateThemeColour(_ colour: UIColor) {
+        PLUSBtn.backgroundColor = colour
+        SUBBtn.backgroundColor = colour
+        MULTBtn.backgroundColor = colour
+        DIVBtn.backgroundColor = colour
+        EQUALSBtn.backgroundColor = colour
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-        
+
         outputLabel.accessibilityIdentifier = "Binary Output Label"
         updateOutputLabel(value: binaryDefaultLabel)
-        
+
         if let savedPreferences = DataPersistence.loadPreferences() {
-            PLUSBtn.backgroundColor = savedPreferences.colour
-            SUBBtn.backgroundColor = savedPreferences.colour
-            MULTBtn.backgroundColor = savedPreferences.colour
-            DIVBtn.backgroundColor = savedPreferences.colour
-            EQUALSBtn.backgroundColor = savedPreferences.colour
-            
+            updateThemeColour(savedPreferences.colour)
             setupCalculatorTextColour(state: savedPreferences.setCalculatorTextColour, colourToSet: savedPreferences.colour)
         }
-        
-        //Setup gesture recognizers
-        self.setupOutputLabelGestureRecognizers()
-        
-        // Force light mode to be used (for now) - to hide the navigation bar line
+
+        setupOutputLabelGestureRecognizers()
         overrideUserInterfaceStyle = .light
-        
         ReviewManager.requestReviewIfAppropriate()
     }
-    
+
     override func viewDidLayoutSubviews() {
-        // Setup Binary View Controller constraints
         let screenWidth = view.bounds.width
         let screenHeight = view.bounds.height
-        
+
         let hStacks = [binHStack1!, binHStack2!, binHStack3!, binHStack4!, binHStack5!]
         let singleButtons = [DIVBtn!, MULTBtn!, SUBBtn!, PLUSBtn!, EQUALSBtn!, DELBtn!, XORBtn!, ORBtn!, ANDBtn!, NOTBtn!,
                              ONESBtn!, TWOSBtn!, LSBtn!, RSBtn!, Btn0!, Btn1!, Btn00!, Btn11!]
         let doubleButtons = [ACBtn!]
-        
-        if (UIDevice.current.userInterfaceIdiom == .pad) {
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
             let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: binVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
             currentConstraints.append(contentsOf: stackConstraints)
-            
+
             let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
             currentConstraints.append(contentsOf: buttonConstraints)
-            
+
             let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
             currentConstraints.append(contentsOf: labelConstraints)
-            
+
             NSLayoutConstraint.activate(currentConstraints)
         }
         else {
             let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: binVStack, outputLabel: outputLabel, screenWidth: screenWidth)
             NSLayoutConstraint.activate(stackConstraints)
-            
+
             let buttonConstraints = UIHelper.setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: 2)
             NSLayoutConstraint.activate(buttonConstraints)
-            
+
             let labelConstraints = UIHelper.setupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, calculator: 2)
             NSLayoutConstraint.activate(labelConstraints)
         }
     }
-    
-    //Load the current converted value from either of the other calculator screens
+
+    // Load the current converted value from either of the other calculator screens
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        //Check for integer overflow first
+
         if ((stateController?.convValues.largerThan64Bits)!) {
             updateOutputLabel(value: "Error! Integer Overflow!")
             telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Overflow)
@@ -146,11 +152,8 @@ class BinaryViewController: UIViewController, HistoryButtonHost {
                 result = ""
                 currentOperation = .NULL
             }
-                //Need to format for binary representation
             else {
-                //Check if the binary string is negative
                 if (newLabelValue!.contains("-")) {
-                    //Need to convert to signed binary notation
                     newLabelValue = formatNegativeBinaryString(stringToConvert: newLabelValue ?? binaryDefaultLabel)
                 }
                 runningNumber = newLabelValue ?? ""
@@ -159,150 +162,450 @@ class BinaryViewController: UIViewController, HistoryButtonHost {
             }
             updateOutputLabel(value: newLabelValue ?? binaryDefaultLabel)
         }
-        
-        setupHistoryButton()
-        updateHistoryButton(stateController: stateController)
-        
-        //Set button colour based on state controller
-        if (stateController?.convValues.colour != nil){
-            PLUSBtn.backgroundColor = stateController?.convValues.colour
-            SUBBtn.backgroundColor = stateController?.convValues.colour
-            MULTBtn.backgroundColor = stateController?.convValues.colour
-            DIVBtn.backgroundColor = stateController?.convValues.colour
-            EQUALSBtn.backgroundColor = stateController?.convValues.colour
-            historyButton.tintColor = stateController?.convValues.colour
-        }
-        
-        // Small optimization to only delay single tap if absolutely necessary
-        if (((stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) && currentlyRecognizingDoubleTap == false) ||
-            ((stateController?.convValues.copyActionIndex != 1 && stateController?.convValues.pasteActionIndex != 1) && currentlyRecognizingDoubleTap == true)) {
-            outputLabel.gestureRecognizers?.forEach(outputLabel.removeGestureRecognizer)
-            self.setupOutputLabelGestureRecognizers()
-        }
-        
-        // Check if local history needs to be cleared (middle/second bit of flag)
-        let flag = ((stateController?.convValues.clearLocalHistory ?? 0) & 2) >> 1
-        if flag == 1 {
-            calculationHistory = []
-            // Clear the middle (second bit)
-            stateController?.convValues.clearLocalHistory &= 5
-        }
-        
-        //Set calculator text colour
-        setupCalculatorTextColour(state: stateController?.convValues.setCalculatorTextColour ?? false, colourToSet: stateController?.convValues.colour ?? UIColor.systemGreen)
+
+        setupCommonViewWillAppear()
     }
-    
-    // iPad support is for portrait and landscape mode, need to alter constraints on device rotation
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        
-        // Deactivate current contraints and remove them from the list, new constraints will be calculated and activated as device rotates
-        if (UIDevice.current.userInterfaceIdiom == .pad) {
-            NSLayoutConstraint.deactivate(currentConstraints)
-            currentConstraints.removeAll()
+
+    //MARK: Button Actions
+    @IBAction func numberPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) {
+            runningNumber = ""
         }
-    }
-    
-    @objc func labelSingleTapped(_ sender: UITapGestureRecognizer) {
-        // Only perform action on single tap if user has that setting option enabled
-        if (stateController?.convValues.copyActionIndex == 0 || stateController?.convValues.pasteActionIndex == 0) {
-            // Decide which actions should be performed by a single tap
-            if (stateController?.convValues.copyActionIndex == 0 && stateController?.convValues.pasteActionIndex == 0) {
-                self.copyAndPasteSelected()
+
+        if runningNumber.count <= 63 {
+            let digit = "\(sender.tag)"
+            if ((digit == "0" || digit == "100") && (outputLabel.text == binaryDefaultLabel)) {
+                //if 0 is pressed and calculator is showing 0 then do nothing
             }
-            else if (stateController?.convValues.copyActionIndex == 0) {
-                self.copySelected()
+            else if ((runningNumber.count == 63) && (digit == "100" || digit == "11")) {
+                //if 00 or 11 is pressed and there is only 1 place left to fill then do nothing
             }
             else {
-                self.pasteSelected()
+                var stringToAdd = "\(sender.tag)"
+                if (sender.tag == 100) {
+                    stringToAdd = "00"
+                }
+                runningNumber += stringToAdd
+                var newLabelValue = runningNumber
+                newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
+                updateOutputLabel(value: newLabelValue)
+                quickUpdateStateController()
             }
         }
     }
-    
-    @objc func labelDoubleTapped(_ sender: UILongPressGestureRecognizer) {
-        // Only perform action on double tap if user has that setting option enabled
-        if (stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) {
-            // Decide which actions should be performed by a double tap
-            if (stateController?.convValues.copyActionIndex == 1 && stateController?.convValues.pasteActionIndex == 1) {
-                self.copyAndPasteSelected()
-            }
-            else if (stateController?.convValues.copyActionIndex == 1) {
-                self.copySelected()
-            }
-            else {
-                self.pasteSelected()
-            }
-        }
+
+    @IBAction func ACPressed(_ sender: RoundButton) {
+        runningNumber = ""
+        leftValue = ""
+        rightValue = ""
+        result = ""
+        currentOperation = .NULL
+        updateOutputLabel(value: binaryDefaultLabel)
+
+        stateController?.convValues.largerThan64Bits = false
+        stateController?.convValues.decimalVal = "0"
+        stateController?.convValues.hexVal = "0"
+        stateController?.convValues.binVal = "0"
     }
-    
-    @objc func historyButtonTapped() {
-        presentHistory(calculationHistory: calculationHistory)
-    }
-    
-    func copySelected() {
-        var currentOutput = runningNumber;
-        if (runningNumber == ""){
-            //Need to do some processing as the binary label has extra formatting
-            currentOutput = outputLabel.text ?? binaryDefaultLabel
-            currentOutput = currentOutput.replacingOccurrences(of: " ", with: "")
-            var end = false
-            for char in currentOutput {
-                if (char == "0" && end == false){
-                    currentOutput.remove(at: currentOutput.startIndex)
+
+    @IBAction func deletePressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) { return }
+
+        var currentLabel = outputLabel.text
+        if (currentLabel != binaryDefaultLabel) {
+            if (runningNumber != "") {
+                runningNumber.removeLast()
+                if (runningNumber == "") {
+                    stateController?.convValues.largerThan64Bits = false
+                    stateController?.convValues.decimalVal = "0"
+                    stateController?.convValues.hexVal = "0"
+                    stateController?.convValues.binVal = "0"
+                    updateOutputLabel(value: binaryDefaultLabel)
                 }
                 else {
-                    end = true
+                    currentLabel = runningNumber
+                    currentLabel = formatBinaryString(stringToConvert: currentLabel ?? binaryDefaultLabel)
+                    updateOutputLabel(value: currentLabel ?? binaryDefaultLabel)
+                    quickUpdateStateController()
                 }
             }
-            
-            if (currentOutput == ""){
-                currentOutput = "0"
+        }
+    }
+
+    @IBAction func leftShiftPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) { return }
+
+        var currentValue = ""
+        if runningNumber != "" {
+            let binLeftValue = runningNumber
+
+            if (runningNumber.first == "1" && runningNumber.count == 64) {
+                currentValue = String(Int64(bitPattern: UInt64(runningNumber, radix: 2)!))
+            }
+            else {
+                currentValue = String(Int(runningNumber, radix: 2)!)
+            }
+            currentValue = "\(Int(currentValue)! << 1)"
+
+            stateController?.convValues.decimalVal = currentValue
+            let hexConversion = String(Int64(currentValue)!, radix: 16)
+            let binConversion = String(Int64(currentValue)!, radix: 2)
+            stateController?.convValues.hexVal = hexConversion
+            stateController?.convValues.binVal = binConversion
+
+            var newLabelValue = binConversion
+            if (binConversion.contains("-")) {
+                newLabelValue = formatNegativeBinaryString(stringToConvert: binConversion)
+            }
+            runningNumber = newLabelValue
+            let labelValueBeforeSpaces = newLabelValue
+            newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
+            updateOutputLabel(value: newLabelValue)
+
+            let unaryCalculationResult = labelValueBeforeSpaces == "" ? "0" : labelValueBeforeSpaces
+            let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "1", operation: .LeftShift, result: unaryCalculationResult, isUnaryOperation: false)
+            calculationHistory.insert(calculationData, at: 0)
+        }
+    }
+
+    @IBAction func rightShiftPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) { return }
+
+        if runningNumber != "" {
+            let binLeftValue = runningNumber
+
+            let currLabel = outputLabel.text
+            let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+            let rightShifted = String(Int(UInt64(spacesRemoved.dropLast(), radix: 2)!))
+
+            stateController?.convValues.decimalVal = rightShifted
+            let hexConversion = String(Int64(rightShifted)!, radix: 16)
+            let binConversion = String(Int64(rightShifted)!, radix: 2)
+            stateController?.convValues.hexVal = hexConversion
+            stateController?.convValues.binVal = binConversion
+
+            var newLabelValue = binConversion
+            if (binConversion.contains("-")) {
+                newLabelValue = formatNegativeBinaryString(stringToConvert: binConversion)
+            }
+            runningNumber = newLabelValue
+            let labelValueBeforeSpaces = newLabelValue
+            newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
+            updateOutputLabel(value: newLabelValue)
+
+            let unaryCalculationResult = labelValueBeforeSpaces == "" ? "0" : labelValueBeforeSpaces
+            let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "1", operation: .RightShift, result: unaryCalculationResult, isUnaryOperation: false)
+            calculationHistory.insert(calculationData, at: 0)
+        }
+    }
+
+    @IBAction func onesCompPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) { return }
+
+        let binLeftValue = runningNumber == "" ? "0" : runningNumber
+
+        let currLabel = outputLabel.text
+        let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+        let castInt = UInt64(spacesRemoved, radix: 2)!
+        let onesComplimentInt = ~castInt
+        let onesComplimentString = String(onesComplimentInt, radix: 2)
+
+        if (onesComplimentString.first == "1" && onesComplimentString.count == 64) {
+            runningNumber = onesComplimentString
+        }
+        else {
+            let asInt = Int(onesComplimentString)
+            let removedLeadingZeroes = "\(asInt ?? 0)"
+            runningNumber = removedLeadingZeroes
+        }
+        var newLabelValue = onesComplimentString
+        newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
+        updateOutputLabel(value: newLabelValue)
+
+        let unaryCalculationResult = onesComplimentString == "" ? "0" : onesComplimentString
+        let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "", operation: .Not, result: unaryCalculationResult, isUnaryOperation: true)
+        calculationHistory.insert(calculationData, at: 0)
+
+        quickUpdateStateController()
+    }
+
+    @IBAction func twosCompPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true || outputLabel.text == binaryDefaultLabel) { return }
+
+        let currLabel = outputLabel.text
+        let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+        let castInt = UInt64(spacesRemoved, radix: 2)!
+        let twosComplimentInt = ~castInt + 1
+        let twosComplimentString = String(twosComplimentInt, radix: 2)
+
+        if (twosComplimentString.first == "1" && twosComplimentString.count == 64) {
+            runningNumber = twosComplimentString
+        }
+        else {
+            let asInt = Int(twosComplimentString)
+            let removedLeadingZeroes = "\(asInt ?? 0)"
+            runningNumber = removedLeadingZeroes
+        }
+        var newLabelValue = twosComplimentString
+        newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
+        updateOutputLabel(value: newLabelValue)
+
+        quickUpdateStateController()
+    }
+
+    @IBAction func XORPressed(_ sender: RoundButton) {
+        operation(operation: .XOR)
+    }
+
+    @IBAction func ORPressed(_ sender: RoundButton) {
+        operation(operation: .OR)
+    }
+
+    @IBAction func ANDPressed(_ sender: RoundButton) {
+        operation(operation: .AND)
+    }
+
+    @IBAction func NOTPressed(_ sender: RoundButton) {
+        onesCompPressed(sender)
+    }
+
+    @IBAction func dividePressed(_ sender: RoundButton) {
+        operation(operation: .Divide)
+    }
+
+    @IBAction func multiplyPressed(_ sender: RoundButton) {
+        operation(operation: .Multiply)
+    }
+
+    @IBAction func minusPressed(_ sender: RoundButton) {
+        operation(operation: .Subtract)
+    }
+
+    @IBAction func addPressed(_ sender: RoundButton) {
+        operation(operation: .Add)
+    }
+
+    @IBAction func equalsPressed(_ sender: RoundButton) {
+        operation(operation: currentOperation)
+
+        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
+        ReviewManager.incrementReviewWorthyCount()
+    }
+
+    //MARK: Private Functions
+
+    private func operation(operation: Operation) {
+        if currentOperation != .NULL {
+            if runningNumber != "" {
+
+                leftBinValue = runningNumber
+
+                if (runningNumber.first == "1" && runningNumber.count == 64) {
+                    rightValue = String(Int64(bitPattern: UInt64(runningNumber, radix: 2)!))
+                }
+                else {
+                    rightValue = String(Int(runningNumber, radix: 2)!)
+                }
+                runningNumber = ""
+
+                switch (currentOperation) {
+                case .Add:
+                    let overCheck = Int64(leftValue)!.addingReportingOverflow(Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! + Int(rightValue)!)"
+                    }
+
+                case .Subtract:
+                    let overCheck = Int64(leftValue)!.subtractingReportingOverflow(Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! - Int(rightValue)!)"
+                    }
+
+                case .Multiply:
+                    let overCheck = Int64(leftValue)!.multipliedReportingOverflow(by: Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! * Int(rightValue)!)"
+                    }
+
+                case .Divide:
+                    if Int(rightValue)! == 0 {
+                        result = "Error!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        return
+                    }
+                    let overCheck = Int64(leftValue)!.dividedReportingOverflow(by: Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! / Int(rightValue)!)"
+                    }
+
+                case .AND:
+                    result = "\(Int(leftValue)! & Int(rightValue)!)"
+
+                case .OR:
+                    result = "\(Int(leftValue)! | Int(rightValue)!)"
+
+                case .XOR:
+                    result = "\(Int(leftValue)! ^ Int(rightValue)!)"
+
+                default:
+                    fatalError("Unexpected Operation...")
+                }
+
+                leftValue = result
+                setupStateControllerValues()
+
+                let binaryRepresentation = stateController?.convValues.binVal ?? binaryDefaultLabel
+                var newLabelValue = binaryRepresentation
+                if (binaryRepresentation.contains("-")) {
+                    newLabelValue = formatNegativeBinaryString(stringToConvert: binaryRepresentation)
+                }
+                let labelValueBeforeSpaces = newLabelValue
+                newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
+                updateOutputLabel(value: newLabelValue)
+
+                let calculationData = CalculationData(leftValue: leftBinValue, rightValue: rightBinValue, operation: operation, result: labelValueBeforeSpaces, isUnaryOperation: false)
+                calculationHistory.insert(calculationData, at: 0)
+
+                rightBinValue = newLabelValue
+            }
+            currentOperation = operation
+        }
+        else {
+            rightBinValue = runningNumber
+            if runningNumber == "" {
+                if (leftValue == "") {
+                    leftValue = "0"
+                }
+            }
+            else {
+                if (runningNumber.first == "1" && runningNumber.count == 64) {
+                    leftValue = String(Int64(bitPattern: UInt64(runningNumber, radix: 2)!))
+                }
+                else {
+                    leftValue = String(Int(runningNumber, radix: 2)!)
+                }
+            }
+            runningNumber = ""
+            currentOperation = operation
+        }
+    }
+
+    func formatBinaryString(stringToConvert: String) -> String {
+        var manipulatedStringToConvert = stringToConvert
+        while (manipulatedStringToConvert.count < 64) {
+            manipulatedStringToConvert = "0" + manipulatedStringToConvert
+        }
+        return manipulatedStringToConvert.separate(every: 4, with: " ")
+    }
+
+    func formatNegativeBinaryString(stringToConvert: String) -> String {
+        var manipulatedStringToConvert = stringToConvert
+        manipulatedStringToConvert.removeFirst()
+        var newString = ""
+
+        for i in 0..<manipulatedStringToConvert.count {
+            if (manipulatedStringToConvert[manipulatedStringToConvert.index(manipulatedStringToConvert.startIndex, offsetBy: i)] == "0") {
+                newString += "1"
+            }
+            else {
+                newString += "0"
             }
         }
 
-        let pasteboard = UIPasteboard.general
-        pasteboard.string = currentOutput
-        
-        //Alert the user that the output was copied to their clipboard
-        let alert = UIAlertController(title: "Copied to Clipboard", message: currentOutput + " has been added to your clipboard.", preferredStyle: .alert)
-        self.present(alert, animated: true, completion: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            alert.dismiss(animated: true, completion: nil)
+        let index = newString.lastIndex(of: "0") ?? (newString.endIndex)
+        var newSubString = String(newString.prefix(upTo: index))
+
+        if (newSubString.count < newString.count) {
+            newSubString = newSubString + "1"
         }
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Copy)
-    }
-    
-    func pasteSelected() {
-        let alert = UIAlertController(title: "Paste from Clipboard", message: "Press confirm to paste the contents of your clipboard into HexaCalc.", preferredStyle: .alert)
+        while (newSubString.count < newString.count) {
+            newSubString = newSubString + "0"
+        }
+        while (newSubString.count < 64) {
+            newSubString = "1" + newSubString
+        }
 
-        alert.addAction(UIAlertAction(title: "Confirm", style: .default, handler: {_ in self.pasteFromClipboardToBinaryCalculator()}))
-        alert.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
-        
-        self.present(alert, animated: true)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Paste)
+        return newSubString
     }
-    
-    func copyAndPasteSelected() {
-        let alert = UIAlertController(title: "Select Clipboard Action", message: "Press the action that you would like to perform.", preferredStyle: .alert)
 
-        alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: {_ in self.copySelected()}))
-        alert.addAction(UIAlertAction(title: "Paste", style: .default, handler: {_ in self.pasteFromClipboardToBinaryCalculator()}))
-        
-        self.present(alert, animated: true)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.CopyAndPaste)
+    private func setupStateControllerValues() {
+        stateController?.convValues.decimalVal = result
+        let hexConversion = String(Int(result)!, radix: 16)
+        let binConversion = String(Int(result)!, radix: 2)
+        stateController?.convValues.hexVal = hexConversion
+        stateController?.convValues.binVal = binConversion
     }
-    
-    func pasteFromClipboardToBinaryCalculator() {
+
+    private func quickUpdateStateController() {
+
+        if (runningNumber.count < 65) {
+            stateController?.convValues.largerThan64Bits = false
+        }
+
+        stateController?.convValues.binVal = runningNumber
+        var hexCurrentVal = ""
+        var decCurrentVal = ""
+        if (outputLabel.text?.first == "1") {
+            let currLabel = outputLabel.text
+            let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+            stateController?.convValues.binVal = spacesRemoved
+            decCurrentVal = String(Int64(bitPattern: UInt64(spacesRemoved, radix: 2)!))
+            hexCurrentVal = String(Int64(bitPattern: UInt64(spacesRemoved, radix: 2)!), radix: 16)
+        }
+        else {
+            hexCurrentVal = String(Int(runningNumber, radix: 2)!, radix: 16)
+            decCurrentVal = String(Int(runningNumber, radix: 2)!)
+        }
+        stateController?.convValues.hexVal = hexCurrentVal
+        stateController?.convValues.decimalVal = decCurrentVal
+    }
+
+    private func pasteFromClipboardToBinaryCalculator() {
         var pastedInput = ""
         let pasteboard = UIPasteboard.general
         pastedInput = pasteboard.string ?? "0"
-        
-        //Validate input is a hexadecimal value
+
         let chars = CharacterSet(charactersIn: "01").inverted
-        let strippedSpacesBinary =  pastedInput.components(separatedBy: .whitespacesAndNewlines).joined()
+        let strippedSpacesBinary = pastedInput.components(separatedBy: .whitespacesAndNewlines).joined()
         let isValidBinary = strippedSpacesBinary.uppercased().rangeOfCharacter(from: chars) == nil
         if (isValidBinary && strippedSpacesBinary.count <= 64) {
             if (pastedInput == "0") {
@@ -325,561 +628,9 @@ class BinaryViewController: UIViewController, HistoryButtonHost {
             if (isValidBinary) {
                 alertMessage = "The binary string in your clipboard must have a length of 64 characters or less."
             }
-            //Alert the user why the paste failed
             let alert = UIAlertController(title: "Paste Failed", message: alertMessage, preferredStyle: .alert)
-
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            
             self.present(alert, animated: true)
         }
     }
-    
-    //Function to handle a swipe
-    @objc func handleLabelSwipes(_ sender:UISwipeGestureRecognizer) {
-        
-        //Make sure the label was swiped
-        guard (sender.view as? UILabel) != nil else { return }
-        
-        if (sender.direction == .left || sender.direction == .right) {
-            deletePressed(DELBtn)
-            telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.DeleteSwipe)
-        }
-    }
-    
-    //Function for setting up output label gesture recognizers
-    func setupOutputLabelGestureRecognizers() {
-        let labelSingleTap = UITapGestureRecognizer(target: self, action: #selector(self.labelSingleTapped(_:)))
-        labelSingleTap.numberOfTapsRequired = 1
-        let labelDoubleTap = UITapGestureRecognizer(target: self, action: #selector(self.labelDoubleTapped(_:)))
-        labelDoubleTap.numberOfTapsRequired = 2
-        let leftSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
-        let rightSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
-            
-        leftSwipe.direction = .left
-        rightSwipe.direction = .right
-
-        self.outputLabel.addGestureRecognizer(leftSwipe)
-        self.outputLabel.addGestureRecognizer(rightSwipe)
-        self.outputLabel.isUserInteractionEnabled = true
-        self.outputLabel.addGestureRecognizer(labelSingleTap)
-        self.outputLabel.addGestureRecognizer(labelDoubleTap)
-        
-        currentlyRecognizingDoubleTap = false
-        
-        // Small optimization to only delay single tap if absolutely necessary
-        if (stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) {
-            labelSingleTap.require(toFail: labelDoubleTap)
-            currentlyRecognizingDoubleTap = true
-        }
-    }
-
-    //MARK: Button Actions
-    @IBAction func numberPressed(_ sender: RoundButton) {
-        
-        if (stateController?.convValues.largerThan64Bits == true){
-            runningNumber = ""
-        }
-        
-        //Limit number of bits to 64
-        if runningNumber.count <= 63 {
-            let digit = "\(sender.tag)"
-            if ((digit == "0" || digit == "100") && (outputLabel.text == binaryDefaultLabel)){
-                //if 0 is pressed and calculator is showing 0 then do nothing
-            }
-            else if ((runningNumber.count == 63) && (digit == "100" || digit == "11")){
-                //if 00 or 11 is pressed and there is only 1 place left to fill then do nothing
-            }
-            else {
-                var stringToAdd = "\(sender.tag)"
-                //special case for 00 as tag is 100
-                if (sender.tag == 100){
-                    stringToAdd = "00"
-                }
-                runningNumber += stringToAdd
-                var newLabelValue = runningNumber
-                newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
-                updateOutputLabel(value: newLabelValue)
-                quickUpdateStateController()
-            }
-        }
-    }
-    
-    @IBAction func ACPressed(_ sender: RoundButton) {
-        runningNumber = ""
-        leftValue = ""
-        rightValue = ""
-        result = ""
-        currentOperation = .NULL
-        updateOutputLabel(value: binaryDefaultLabel)
-        
-        stateController?.convValues.largerThan64Bits = false
-        stateController?.convValues.decimalVal = "0"
-        stateController?.convValues.hexVal = "0"
-        stateController?.convValues.binVal = "0"
-    }
-    
-    @IBAction func deletePressed(_ sender: RoundButton) {
-        
-        //Button not available during error state
-        if (stateController?.convValues.largerThan64Bits == true){
-            return
-        }
-        
-        var currentLabel = outputLabel.text
-        if (currentLabel != binaryDefaultLabel){
-            if (runningNumber != ""){
-                runningNumber.removeLast()
-                // Need to be careful if runningNumber becomes empty
-                if (runningNumber == "") {
-                    stateController?.convValues.largerThan64Bits = false
-                    stateController?.convValues.decimalVal = "0"
-                    stateController?.convValues.hexVal = "0"
-                    stateController?.convValues.binVal = "0"
-                    updateOutputLabel(value: binaryDefaultLabel)
-                }
-                else {
-                    currentLabel = runningNumber
-                    currentLabel = formatBinaryString(stringToConvert: currentLabel ?? binaryDefaultLabel)
-                    updateOutputLabel(value: currentLabel ?? binaryDefaultLabel)
-                    quickUpdateStateController()
-                }
-            }
-        }
-    }
-    
-    //Instead of making left shift an operation, just complete it whenever it is pressed the first time (doesn't need 2 arguments)
-    @IBAction func leftShiftPressed(_ sender: RoundButton) {
-        
-        //Button not available during error state
-        if (stateController?.convValues.largerThan64Bits == true){
-            return
-        }
-        
-        //If running number is empty then it will just stay as 0
-        var currentValue = ""
-        if runningNumber != "" {
-            let binLeftValue = runningNumber
-            
-            if (runningNumber.first == "1" && runningNumber.count == 64){
-                currentValue = String(Int64(bitPattern: UInt64(runningNumber, radix: 2)!))
-            }
-            else {
-                currentValue = String(Int(runningNumber, radix: 2)!)
-            }
-            currentValue = "\(Int(currentValue)! << 1)"
-            
-            //Update the state controller
-            stateController?.convValues.decimalVal = currentValue
-            let hexConversion = String(Int64(currentValue)!, radix: 16)
-            let binConversion = String(Int64(currentValue)!, radix: 2)
-            stateController?.convValues.hexVal = hexConversion
-            stateController?.convValues.binVal = binConversion
-            
-            var newLabelValue = binConversion
-            if ((binConversion.contains("-"))){
-                newLabelValue = formatNegativeBinaryString(stringToConvert: binConversion)
-            }
-            runningNumber = newLabelValue
-            let labelValueBeforeSpaces = newLabelValue
-            newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
-            updateOutputLabel(value: newLabelValue)
-            
-            // Add to calculation history
-            let unaryCalculationResult = labelValueBeforeSpaces == "" ? "0" : labelValueBeforeSpaces
-            let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "1", operation: .LeftShift, result: unaryCalculationResult, isUnaryOperation: false)
-            calculationHistory.insert(calculationData, at: 0)
-        }
-    }
-    
-    //Instead of making right shift an operation, just complete it whenever it is pressed the first time (doesn't need 2 arguments)
-    @IBAction func rightShiftPressed(_ sender: RoundButton) {
-        
-        //Button not available during error state
-        if (stateController?.convValues.largerThan64Bits == true){
-            return
-        }
-        
-        //If running number is empty then it will just stay as 0
-        if runningNumber != "" {
-            let binLeftValue = runningNumber
-            
-            let currLabel = outputLabel.text
-            let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
-            let rightShifted = String(Int(UInt64(spacesRemoved.dropLast(), radix: 2)!))
-            
-            //Update the state controller
-            stateController?.convValues.decimalVal = rightShifted
-            let hexConversion = String(Int64(rightShifted)!, radix: 16)
-            let binConversion = String(Int64(rightShifted)!, radix: 2)
-            stateController?.convValues.hexVal = hexConversion
-            stateController?.convValues.binVal = binConversion
-            
-            var newLabelValue = binConversion
-            if ((binConversion.contains("-"))){
-                newLabelValue = formatNegativeBinaryString(stringToConvert: binConversion)
-            }
-            runningNumber = newLabelValue
-            let labelValueBeforeSpaces = newLabelValue
-            newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
-            updateOutputLabel(value: newLabelValue)
-            
-            // Add to calculation history
-            let unaryCalculationResult = labelValueBeforeSpaces == "" ? "0" : labelValueBeforeSpaces
-            let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "1", operation: .RightShift, result: unaryCalculationResult, isUnaryOperation: false)
-            calculationHistory.insert(calculationData, at: 0)
-        }
-    }
-    
-    //Ones compliment involves flipping all the bits
-    @IBAction func onesCompPressed(_ sender: RoundButton) {
-        
-        //Button not available during error state
-        if (stateController?.convValues.largerThan64Bits == true){
-            return
-        }
-        
-        let binLeftValue = runningNumber == "" ? "0" : runningNumber
-        
-        let currLabel = outputLabel.text
-        let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
-        let castInt = UInt64(spacesRemoved, radix: 2)!
-        let onesComplimentInt = ~castInt
-        
-        let onesComplimentString = String(onesComplimentInt, radix: 2)
-        
-        //Check if new value is negative or positive
-        if (onesComplimentString.first == "1" && onesComplimentString.count == 64){
-            runningNumber = onesComplimentString
-        }
-        else {
-            let asInt = Int(onesComplimentString)
-            let removedLeadingZeroes = "\(asInt ?? 0)"
-            runningNumber = removedLeadingZeroes
-        }
-        var newLabelValue = onesComplimentString
-        newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
-        updateOutputLabel(value: newLabelValue)
-        
-        // Add to calculation history
-        let unaryCalculationResult = onesComplimentString == "" ? "0" : onesComplimentString
-        let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "", operation: .Not, result: unaryCalculationResult, isUnaryOperation: true)
-        calculationHistory.insert(calculationData, at: 0)
-        
-        quickUpdateStateController()
-    }
-    
-    //Twos complement involves flipping all the bits and then adding 1
-    @IBAction func twosCompPressed(_ sender: RoundButton) {
-        
-        //Button not available during error state or when the value is 0
-        if (stateController?.convValues.largerThan64Bits == true || outputLabel.text == binaryDefaultLabel){
-            return
-        }
-        
-        let currLabel = outputLabel.text
-        let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
-        let castInt = UInt64(spacesRemoved, radix: 2)!
-        let twosComplimentInt = ~castInt + 1
-        
-        let twosComplimentString = String(twosComplimentInt, radix: 2)
-        
-        //Check if new value is negative or positive
-        if (twosComplimentString.first == "1" && twosComplimentString.count == 64){
-            runningNumber = twosComplimentString
-        }
-        else {
-            let asInt = Int(twosComplimentString)
-            let removedLeadingZeroes = "\(asInt ?? 0)"
-            runningNumber = removedLeadingZeroes
-        }
-        var newLabelValue = twosComplimentString
-        newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
-        updateOutputLabel(value: newLabelValue)
-        
-        quickUpdateStateController()
-    }
-    
-    @IBAction func XORPressed(_ sender: RoundButton) {
-        operation(operation: .XOR)
-    }
-    
-    @IBAction func ORPressed(_ sender: RoundButton) {
-        operation(operation: .OR)
-    }
-    
-    @IBAction func ANDPressed(_ sender: RoundButton) {
-        operation(operation: .AND)
-    }
-    
-    @IBAction func NOTPressed(_ sender: RoundButton) {
-        onesCompPressed(sender)
-    }
-    
-    @IBAction func dividePressed(_ sender: RoundButton) {
-        operation(operation: .Divide)
-    }
-    
-    @IBAction func multiplyPressed(_ sender: RoundButton) {
-        operation(operation: .Multiply)
-    }
-    
-    @IBAction func minusPressed(_ sender: RoundButton) {
-        operation(operation: .Subtract)
-    }
-    
-    @IBAction func addPressed(_ sender: RoundButton) {
-        operation(operation: .Add)
-    }
-    
-    @IBAction func equalsPressed(_ sender: RoundButton) {
-        operation(operation: currentOperation)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
-        
-        // Completing calculation is a review worthy action
-        ReviewManager.incrementReviewWorthyCount()
-    }
-    
-    //MARK: Private Functions
-    private func operation(operation: Operation) {
-        if currentOperation != .NULL {
-            if runningNumber != "" {
-                
-                leftBinValue = runningNumber
-                
-                if (runningNumber.first == "1" && runningNumber.count == 64){
-                    rightValue = String(Int64(bitPattern: UInt64(runningNumber, radix: 2)!))
-                }
-                else {
-                    rightValue = String(Int(runningNumber, radix: 2)!)
-                }
-                runningNumber = ""
-                
-                switch (currentOperation) {
-                case .Add:
-                    
-                    //Check for an oveflow
-                    let overCheck = Int64(leftValue)!.addingReportingOverflow(Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! + Int(rightValue)!)"
-                    }
-                    
-                case .Subtract:
-
-                    //Check for an overflow
-                    let overCheck = Int64(leftValue)!.subtractingReportingOverflow(Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! - Int(rightValue)!)"
-                    }
-                    
-                case .Multiply:
-                    
-                    //Check for an overflow
-                    let overCheck = Int64(leftValue)!.multipliedReportingOverflow(by: Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! * Int(rightValue)!)"
-                    }
-                    
-                case .Divide:
-                    //Output Error! if division by 0
-                    if Int(rightValue)! == 0 {
-                        result = "Error!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        return
-                    }
-                    let overCheck = Int64(leftValue)!.dividedReportingOverflow(by: Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! / Int(rightValue)!)"
-                    }
-                    
-                case .AND:
-                result = "\(Int(leftValue)! & Int(rightValue)!)"
-                    
-                case .OR:
-                result = "\(Int(leftValue)! | Int(rightValue)!)"
-                    
-                case .XOR:
-                result = "\(Int(leftValue)! ^ Int(rightValue)!)"
-                
-                //Should not occur
-                default:
-                    fatalError("Unexpected Operation...")
-                }
-                
-                leftValue = result
-                setupStateControllerValues()
-                
-                let binaryRepresentation = stateController?.convValues.binVal ?? binaryDefaultLabel
-                var newLabelValue = binaryRepresentation
-                if ((binaryRepresentation.contains("-"))){
-                    newLabelValue = formatNegativeBinaryString(stringToConvert: binaryRepresentation)
-                }
-                let labelValueBeforeSpaces = newLabelValue
-                newLabelValue = formatBinaryString(stringToConvert: newLabelValue)
-                updateOutputLabel(value: newLabelValue)
-                
-                let calculationData = CalculationData(leftValue: leftBinValue, rightValue: rightBinValue, operation: operation, result: labelValueBeforeSpaces, isUnaryOperation: false)
-                calculationHistory.insert(calculationData, at: 0)
-                
-                rightBinValue = newLabelValue
-            }
-            currentOperation = operation
-        }
-        else {
-            
-            rightBinValue = runningNumber
-            //If string is empty it should be interpreted as a 0
-            if runningNumber == "" {
-                if (leftValue == "") {
-                    leftValue = "0"
-                }
-            }
-            else {
-                if (runningNumber.first == "1" && runningNumber.count == 64){
-                leftValue = String(Int64(bitPattern: UInt64(runningNumber, radix: 2)!))
-                }
-                else {
-                    leftValue = String(Int(runningNumber, radix: 2)!)
-                }
-            }
-            runningNumber = ""
-            currentOperation = operation
-        }
-    }
-    
-    func formatBinaryString(stringToConvert: String) -> String {
-        var manipulatedStringToConvert = stringToConvert
-        while (manipulatedStringToConvert.count < 64){
-            manipulatedStringToConvert = "0" + manipulatedStringToConvert
-        }
-        return manipulatedStringToConvert.separate(every: 4, with: " ")
-    }
-    
-    func formatNegativeBinaryString(stringToConvert: String) -> String {
-        var manipulatedStringToConvert = stringToConvert
-        manipulatedStringToConvert.removeFirst()
-        var newString = ""
-        
-        //Flip all bits
-        for i in 0..<manipulatedStringToConvert.count {
-            if (manipulatedStringToConvert[manipulatedStringToConvert.index(manipulatedStringToConvert.startIndex, offsetBy: i)] == "0"){
-                newString += "1"
-            }
-            else {
-                newString += "0"
-            }
-        }
-        
-        //Add 1 to the string
-        let index = newString.lastIndex(of: "0") ?? (newString.endIndex)
-        var newSubString = String(newString.prefix(upTo: index))
-        
-        
-        if (newSubString.count < newString.count) {
-            newSubString = newSubString + "1"
-        }
-        
-        while (newSubString.count < newString.count) {
-            newSubString = newSubString + "0"
-        }
-        
-        //Sign extend
-        while (newSubString.count < 64) {
-            newSubString = "1" + newSubString
-        }
-        
-        return newSubString
-    }
-    
-    //Perform a full state controller update when a new result is calculated via an operation key
-    private func setupStateControllerValues() {
-        stateController?.convValues.decimalVal = result
-        let hexConversion = String(Int(result)!, radix: 16)
-        let binConversion = String(Int(result)!, radix: 2)
-        stateController?.convValues.hexVal = hexConversion
-        stateController?.convValues.binVal = binConversion
-    }
-    
-    //Perform a quick update to keep the state controller variables in sync with the calculator label
-    private func quickUpdateStateController() {
-        
-        if (runningNumber.count < 65) {
-            stateController?.convValues.largerThan64Bits = false
-        }
-        
-        //Need to keep the state controller updated with what is on the screen
-        stateController?.convValues.binVal = runningNumber
-        //Need to convert differently if binary is positive or negative
-        var hexCurrentVal = ""
-        var decCurrentVal = ""
-        if (outputLabel.text?.first == "1"){
-            let currLabel = outputLabel.text
-            let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
-            stateController?.convValues.binVal = spacesRemoved
-            decCurrentVal = String(Int64(bitPattern: UInt64(spacesRemoved, radix: 2)!))
-            hexCurrentVal = String(Int64(bitPattern: UInt64(spacesRemoved, radix: 2)!), radix: 16)
-        }
-        else {
-            hexCurrentVal = String(Int(runningNumber, radix: 2)!, radix: 16)
-            decCurrentVal = String(Int(runningNumber, radix: 2)!)
-        }
-        stateController?.convValues.hexVal = hexCurrentVal
-        stateController?.convValues.decimalVal = decCurrentVal
-    }
-    
-    //Function to check whether the user wants the output text label colour to be the same as the overall theme
-    private func setupCalculatorTextColour(state: Bool, colourToSet: UIColor){
-        if (state) {
-            outputLabel.textColor = colourToSet
-        }
-        else {
-            outputLabel.textColor = UIColor.white
-        }
-    }
-    
-    // Standardized function to update the output label
-    private func updateOutputLabel(value: String) {
-        outputLabel.text = value
-        outputLabel.accessibilityLabel = value
-    }
-}
-
-//Adds state controller to the view controller
-extension BinaryViewController: StateControllerProtocol {
-  func setState(state: StateController) {
-    self.stateController = state
-  }
 }

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -77,6 +77,9 @@ class BinaryViewController: CalculatorViewController {
         return runningNumber
     }
 
+    override var outputLabelAccessibilityIdentifier: String { "Binary Output Label" }
+    override var defaultLabelValue: String { binaryDefaultLabel }
+
     override func updateThemeColour(_ colour: UIColor) {
         PLUSBtn.backgroundColor = colour
         SUBBtn.backgroundColor = colour
@@ -87,18 +90,8 @@ class BinaryViewController: CalculatorViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        outputLabel.accessibilityIdentifier = "Binary Output Label"
-        updateOutputLabel(value: binaryDefaultLabel)
-
-        if let savedPreferences = DataPersistence.loadPreferences() {
-            updateThemeColour(savedPreferences.colour)
-            setupCalculatorTextColour(state: savedPreferences.setCalculatorTextColour, colourToSet: savedPreferences.colour)
-        }
-
-        setupOutputLabelGestureRecognizers()
-        overrideUserInterfaceStyle = .light
-        ReviewManager.requestReviewIfAppropriate()
+        outputLabel.accessibilityIdentifier = outputLabelAccessibilityIdentifier
+        setupCommonViewDidLoad()
     }
 
     override func viewDidLayoutSubviews() {

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -1,0 +1,243 @@
+//
+//  CalculatorViewController.swift
+//  HexaCalc
+//
+//  Created by Anthony Hopkins on 2026-04-30.
+//  Copyright © 2026 Anthony Hopkins. All rights reserved.
+//
+
+import UIKit
+
+// Base class for all calculator tabs. Holds shared state, gesture handling,
+// clipboard actions, and lifecycle helpers. Subclasses provide the
+// calculator-specific outlet wiring, label updates, and arithmetic logic
+// by overriding the abstract computed properties and methods below.
+class CalculatorViewController: UIViewController, HistoryButtonHost {
+
+    // MARK: Common outlet – connected in IB for each subclass scene
+    @IBOutlet weak var outputLabel: UILabel!
+
+    // MARK: HistoryButtonHost
+    var historyButton: UIButton!
+    var historyButtonWidthConstraint: NSLayoutConstraint?
+
+    // MARK: Shared state
+    var stateController: StateController?
+    var runningNumber = ""
+    var leftValue = ""
+    var rightValue = ""
+    var result = ""
+    var currentOperation: Operation = .NULL
+    var currentConstraints: [NSLayoutConstraint] = []
+    var currentlyRecognizingDoubleTap = false
+    var calculationHistory: [CalculationData] = []
+    let telemetryManager = TelemetryManager.sharedTelemetryManager
+
+    // MARK: Abstract – subclasses must override
+
+    var telemetryTab: TelemetryTab {
+        fatalError("Subclass must override telemetryTab")
+    }
+
+    // Bit mask to read from clearLocalHistory (1 = decimal, 2 = binary, 4 = hex)
+    var historyFlagReadMask: Int32 {
+        fatalError("Subclass must override historyFlagReadMask")
+    }
+
+    // Right-shift to apply after masking (bit 0 → 0, bit 1 → 1, bit 2 → 2)
+    var historyFlagShift: Int32 {
+        fatalError("Subclass must override historyFlagShift")
+    }
+
+    // Mask to AND when clearing this VC's bit from clearLocalHistory
+    var historyFlagClearMask: Int32 {
+        fatalError("Subclass must override historyFlagClearMask")
+    }
+
+    // Called by the swipe-to-delete gesture; forward to the subclass delete action
+    func deleteLastDigit() {
+        fatalError("Subclass must override deleteLastDigit()")
+    }
+
+    // Perform the actual clipboard paste for the specific number system
+    func pasteFromClipboard() {
+        fatalError("Subclass must override pasteFromClipboard()")
+    }
+
+    // Return the text that should be placed on the clipboard when copying
+    func copyTextFromLabel() -> String {
+        fatalError("Subclass must override copyTextFromLabel()")
+    }
+
+    // Apply the current theme colour to all operator buttons (and any other
+    // VC-specific tinted views)
+    func updateThemeColour(_ colour: UIColor) {
+        fatalError("Subclass must override updateThemeColour(_:)")
+    }
+
+    // MARK: Common lifecycle
+
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            NSLayoutConstraint.deactivate(currentConstraints)
+            currentConstraints.removeAll()
+        }
+    }
+
+    // MARK: viewWillAppear helper
+
+    // Call at the end of each subclass viewWillAppear, after updating the label.
+    func setupCommonViewWillAppear() {
+        setupHistoryButton()
+        updateHistoryButton(stateController: stateController)
+
+        if let colour = stateController?.convValues.colour {
+            updateThemeColour(colour)
+            historyButton.tintColor = colour
+        }
+
+        let needsDoubleTap = stateController?.convValues.copyActionIndex == 1
+                          || stateController?.convValues.pasteActionIndex == 1
+        if (needsDoubleTap && !currentlyRecognizingDoubleTap)
+            || (!needsDoubleTap && currentlyRecognizingDoubleTap) {
+            outputLabel.gestureRecognizers?.forEach(outputLabel.removeGestureRecognizer)
+            setupOutputLabelGestureRecognizers()
+        }
+
+        let flag = ((stateController?.convValues.clearLocalHistory ?? 0) & historyFlagReadMask) >> historyFlagShift
+        if flag == 1 {
+            calculationHistory = []
+            stateController?.convValues.clearLocalHistory &= historyFlagClearMask
+        }
+
+        setupCalculatorTextColour(
+            state: stateController?.convValues.setCalculatorTextColour ?? false,
+            colourToSet: stateController?.convValues.colour ?? UIColor.systemGreen
+        )
+    }
+
+    // MARK: Gesture recognizer setup
+
+    func setupOutputLabelGestureRecognizers() {
+        let labelSingleTap = UITapGestureRecognizer(target: self, action: #selector(labelSingleTapped(_:)))
+        labelSingleTap.numberOfTapsRequired = 1
+        let labelDoubleTap = UITapGestureRecognizer(target: self, action: #selector(labelDoubleTapped(_:)))
+        labelDoubleTap.numberOfTapsRequired = 2
+        let leftSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
+        let rightSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
+        leftSwipe.direction = .left
+        rightSwipe.direction = .right
+
+        outputLabel.addGestureRecognizer(leftSwipe)
+        outputLabel.addGestureRecognizer(rightSwipe)
+        outputLabel.isUserInteractionEnabled = true
+        outputLabel.addGestureRecognizer(labelSingleTap)
+        outputLabel.addGestureRecognizer(labelDoubleTap)
+
+        currentlyRecognizingDoubleTap = false
+        if stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1 {
+            labelSingleTap.require(toFail: labelDoubleTap)
+            currentlyRecognizingDoubleTap = true
+        }
+    }
+
+    // MARK: Gesture handlers
+
+    @objc func labelSingleTapped(_ sender: UITapGestureRecognizer) {
+        if stateController?.convValues.copyActionIndex == 0 || stateController?.convValues.pasteActionIndex == 0 {
+            if stateController?.convValues.copyActionIndex == 0 && stateController?.convValues.pasteActionIndex == 0 {
+                copyAndPasteSelected()
+            } else if stateController?.convValues.copyActionIndex == 0 {
+                copySelected()
+            } else {
+                pasteSelected()
+            }
+        }
+    }
+
+    @objc func labelDoubleTapped(_ sender: UILongPressGestureRecognizer) {
+        if stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1 {
+            if stateController?.convValues.copyActionIndex == 1 && stateController?.convValues.pasteActionIndex == 1 {
+                copyAndPasteSelected()
+            } else if stateController?.convValues.copyActionIndex == 1 {
+                copySelected()
+            } else {
+                pasteSelected()
+            }
+        }
+    }
+
+    @objc func historyButtonTapped() {
+        presentHistory(calculationHistory: calculationHistory)
+    }
+
+    @objc func handleLabelSwipes(_ sender: UISwipeGestureRecognizer) {
+        guard sender.view as? UILabel != nil else { return }
+        if sender.direction == .left || sender.direction == .right {
+            deleteLastDigit()
+            telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.DeleteSwipe)
+        }
+    }
+
+    // MARK: Clipboard actions
+
+    func copySelected() {
+        let currentOutput = copyTextFromLabel()
+        UIPasteboard.general.string = currentOutput
+        let alert = UIAlertController(
+            title: "Copied to Clipboard",
+            message: currentOutput + " has been added to your clipboard.",
+            preferredStyle: .alert
+        )
+        present(alert, animated: true, completion: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            alert.dismiss(animated: true, completion: nil)
+        }
+        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Copy)
+    }
+
+    func pasteSelected() {
+        let alert = UIAlertController(
+            title: "Paste from Clipboard",
+            message: "Press confirm to paste the contents of your clipboard into HexaCalc.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Confirm", style: .default, handler: { _ in self.pasteFromClipboard() }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
+        present(alert, animated: true)
+        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Paste)
+    }
+
+    func copyAndPasteSelected() {
+        let alert = UIAlertController(
+            title: "Select Clipboard Action",
+            message: "Press the action that you would like to perform.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: { _ in self.copySelected() }))
+        alert.addAction(UIAlertAction(title: "Paste", style: .default, handler: { _ in self.pasteFromClipboard() }))
+        present(alert, animated: true)
+        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.CopyAndPaste)
+    }
+
+    // MARK: UI helpers
+
+    func setupCalculatorTextColour(state: Bool, colourToSet: UIColor) {
+        outputLabel.textColor = state ? colourToSet : UIColor.white
+    }
+
+    func updateOutputLabel(value: String) {
+        outputLabel.text = value
+        outputLabel.accessibilityLabel = value
+    }
+}
+
+// MARK: StateControllerProtocol
+
+extension CalculatorViewController: StateControllerProtocol {
+    func setState(state: StateController) {
+        self.stateController = state
+    }
+}

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -75,7 +75,29 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         fatalError("Subclass must override updateThemeColour(_:)")
     }
 
+    var outputLabelAccessibilityIdentifier: String {
+        fatalError("Subclass must override outputLabelAccessibilityIdentifier")
+    }
+
+    var defaultLabelValue: String {
+        fatalError("Subclass must override defaultLabelValue")
+    }
+
     // MARK: Common lifecycle
+
+    func setupCommonViewDidLoad() {
+        updateOutputLabel(value: defaultLabelValue)
+        if let colour = stateController?.convValues.colour {
+            updateThemeColour(colour)
+        }
+        setupCalculatorTextColour(
+            state: stateController?.convValues.setCalculatorTextColour ?? false,
+            colourToSet: stateController?.convValues.colour ?? .systemGreen
+        )
+        setupOutputLabelGestureRecognizers()
+        overrideUserInterfaceStyle = .light
+        ReviewManager.requestReviewIfAppropriate()
+    }
 
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -170,7 +170,10 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     }
 
     @objc func historyButtonTapped() {
-        presentHistory(calculationHistory: calculationHistory)
+        guard let historyVC = storyboard?.instantiateViewController(withIdentifier: "CalculationHistoryViewController") as? CalculationHistoryViewController else { return }
+        historyVC.calculationHistory = calculationHistory
+        let nav = UINavigationController(rootViewController: historyVC)
+        present(nav, animated: true)
     }
 
     @objc func handleLabelSwipes(_ sender: UISwipeGestureRecognizer) {

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -64,6 +64,9 @@ class DecimalViewController: CalculatorViewController {
         return runningNumber
     }
 
+    override var outputLabelAccessibilityIdentifier: String { "Decimal Output Label" }
+    override var defaultLabelValue: String { "0" }
+
     override func updateThemeColour(_ colour: UIColor) {
         PLUSBtn.backgroundColor = colour
         SUBBtn.backgroundColor = colour
@@ -74,18 +77,8 @@ class DecimalViewController: CalculatorViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        outputLabel.accessibilityIdentifier = "Decimal Output Label"
-        updateOutputLabel(value: "0")
-
-        if let savedPreferences = DataPersistence.loadPreferences() {
-            updateThemeColour(savedPreferences.colour)
-            setupCalculatorTextColour(state: savedPreferences.setCalculatorTextColour, colourToSet: savedPreferences.colour)
-        }
-
-        setupOutputLabelGestureRecognizers()
-        overrideUserInterfaceStyle = .light
-        ReviewManager.requestReviewIfAppropriate()
+        outputLabel.accessibilityIdentifier = outputLabelAccessibilityIdentifier
+        setupCommonViewDidLoad()
     }
 
     override func viewDidLayoutSubviews() {

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -8,19 +8,16 @@
 
 import UIKit
 
-class DecimalViewController: UIViewController, HistoryButtonHost {
-    
+class DecimalViewController: CalculatorViewController {
+
     //MARK: Properties
-    var stateController: StateController?
-    
     @IBOutlet weak var decVStack: UIStackView!
     @IBOutlet weak var decHStack1: UIStackView!
     @IBOutlet weak var decHStack2: UIStackView!
     @IBOutlet weak var decHStack3: UIStackView!
     @IBOutlet weak var decHStack4: UIStackView!
     @IBOutlet weak var decHStack5: UIStackView!
-    @IBOutlet weak var outputLabel: UILabel!
-    
+
     @IBOutlet weak var ACBtn: RoundButton!
     @IBOutlet weak var SecondFunctionBtn: RoundButton!
     @IBOutlet weak var DELBtn: RoundButton!
@@ -40,98 +37,97 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
     @IBOutlet weak var Btn7: RoundButton!
     @IBOutlet weak var Btn8: RoundButton!
     @IBOutlet weak var Btn9: RoundButton!
-    
-    // Programmatic UIButton
-    var historyButton: UIButton!
-    var historyButtonWidthConstraint: NSLayoutConstraint?
-    
+
     //MARK: Variables
-    var runningNumber = ""
-    var leftValue = ""
-    var rightValue = ""
-    var result = ""
-    var currentOperation: Operation = .NULL
-    
-    // Current contraints are stored for the iPad such that rotating the screen allows constraints to be replaced
-    var currentConstraints: [NSLayoutConstraint] = []
-    
-    var currentlyRecognizingDoubleTap = false
-    
     var secondFunctionMode = false
-    
-    var calculationHistory: [CalculationData] = []
-    
-    // Access singleton TelemetryManager class object
-    let telemetryManager = TelemetryManager.sharedTelemetryManager
-    let telemetryTab = TelemetryTab.Decimal
-    
+
+    // MARK: Abstract overrides
+
+    override var telemetryTab: TelemetryTab { .Decimal }
+    override var historyFlagReadMask: Int32 { 1 }
+    override var historyFlagShift: Int32 { 0 }
+    override var historyFlagClearMask: Int32 { 6 }
+
+    override func deleteLastDigit() {
+        deletePressed(DELBtn)
+    }
+
+    override func pasteFromClipboard() {
+        pasteFromClipboardToDecimalCalculator()
+    }
+
+    override func copyTextFromLabel() -> String {
+        if runningNumber == "" {
+            let currLabel = outputLabel.text
+            return (currLabel?.components(separatedBy: ",").joined(separator: ""))!
+        }
+        return runningNumber
+    }
+
+    override func updateThemeColour(_ colour: UIColor) {
+        PLUSBtn.backgroundColor = colour
+        SUBBtn.backgroundColor = colour
+        MULTBtn.backgroundColor = colour
+        DIVBtn.backgroundColor = colour
+        EQUALSBtn.backgroundColor = colour
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         outputLabel.accessibilityIdentifier = "Decimal Output Label"
         updateOutputLabel(value: "0")
-        
+
         if let savedPreferences = DataPersistence.loadPreferences() {
-            PLUSBtn.backgroundColor = savedPreferences.colour
-            SUBBtn.backgroundColor = savedPreferences.colour
-            MULTBtn.backgroundColor = savedPreferences.colour
-            DIVBtn.backgroundColor = savedPreferences.colour
-            EQUALSBtn.backgroundColor = savedPreferences.colour
-            
+            updateThemeColour(savedPreferences.colour)
             setupCalculatorTextColour(state: savedPreferences.setCalculatorTextColour, colourToSet: savedPreferences.colour)
         }
-        
-        //Setup gesture recognizers
-        self.setupOutputLabelGestureRecognizers()
-        
-        // Force light mode to be used (for now) - to hide the navigation bar line
+
+        setupOutputLabelGestureRecognizers()
         overrideUserInterfaceStyle = .light
-        
         ReviewManager.requestReviewIfAppropriate()
     }
-    
+
     override func viewDidLayoutSubviews() {
-        // Setup Decimal View Controller constraints
         let screenWidth = view.bounds.width
         let screenHeight = view.bounds.height
-        
+
         let hStacks = [decHStack1!, decHStack2!, decHStack3!, decHStack4!, decHStack5!]
         let singleButtons = [DIVBtn!, MULTBtn!, SUBBtn!, PLUSBtn!, EQUALSBtn!, DELBtn!, DOTBtn!, SecondFunctionBtn!,
                              ACBtn!, Btn1!, Btn2!, Btn3!, Btn4!, Btn5!, Btn6!, Btn7!, Btn8!, Btn9!]
         let doubleButtons = [Btn0!]
-        
-        if (UIDevice.current.userInterfaceIdiom == .pad) {
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
             let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: decVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
             currentConstraints.append(contentsOf: stackConstraints)
-            
+
             let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
             currentConstraints.append(contentsOf: buttonConstraints)
-            
+
             let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
             currentConstraints.append(contentsOf: labelConstraints)
-            
+
             NSLayoutConstraint.activate(currentConstraints)
         }
         else {
             let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: decVStack, outputLabel: outputLabel, screenWidth: screenWidth)
             NSLayoutConstraint.activate(stackConstraints)
-            
+
             let buttonConstraints = UIHelper.setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: 2)
             NSLayoutConstraint.activate(buttonConstraints)
-            
+
             let labelConstraints = UIHelper.setupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, calculator: 1)
             NSLayoutConstraint.activate(labelConstraints)
         }
     }
-    
+
     // Load the current converted value from either of the other calculator screens
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         var decimalLabelText = stateController?.convValues.decimalVal
-        
-        //Need to set runningNumber to the current calculation value and reset the current operation
-        if (decimalLabelText != "0"){
+
+        if (decimalLabelText != "0") {
             runningNumber = decimalLabelText ?? ""
             currentOperation = .NULL
         }
@@ -142,14 +138,12 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             result = ""
             currentOperation = .NULL
         }
-        
-        // Check if a conversion to scientific notation is necessary
+
         if ((Double(decimalLabelText ?? "0")! > 999999999 || Double(decimalLabelText ?? "0")! < -999999999) || (decimalLabelText ?? "0").contains("e")) {
             decimalLabelText = "\(Double(decimalLabelText ?? "0")!.scientificFormatted)"
         }
         else {
-            // Check if we need to convert to int
-            if(Double(decimalLabelText ?? "0")!.truncatingRemainder(dividingBy: 1) == 0) {
+            if (Double(decimalLabelText ?? "0")!.truncatingRemainder(dividingBy: 1) == 0) {
                 decimalLabelText = "\(Int(Double(decimalLabelText ?? "0")!))"
                 if (decimalLabelText != "0") {
                     runningNumber = decimalLabelText ?? ""
@@ -157,273 +151,26 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                 decimalLabelText = self.formatDecimalString(stringToConvert: decimalLabelText ?? "0")
             }
         }
-        
-        setupHistoryButton()
-        updateHistoryButton(stateController: stateController)
-        
-        // Set button colour based on state controller
-        if (stateController?.convValues.colour != nil){
-            PLUSBtn.backgroundColor = stateController?.convValues.colour
-            SUBBtn.backgroundColor = stateController?.convValues.colour
-            MULTBtn.backgroundColor = stateController?.convValues.colour
-            DIVBtn.backgroundColor = stateController?.convValues.colour
-            EQUALSBtn.backgroundColor = stateController?.convValues.colour
-            historyButton.tintColor = stateController?.convValues.colour
-        }
-        
-        // Small optimization to only delay single tap if absolutely necessary
-        if (((stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) && currentlyRecognizingDoubleTap == false) ||
-            ((stateController?.convValues.copyActionIndex != 1 && stateController?.convValues.pasteActionIndex != 1) && currentlyRecognizingDoubleTap == true)) {
-            outputLabel.gestureRecognizers?.forEach(outputLabel.removeGestureRecognizer)
-            self.setupOutputLabelGestureRecognizers()
-        }
-        
-        // Check if local history needs to be cleared (LSB of flag)
-        let flag = ((stateController?.convValues.clearLocalHistory ?? 0) & 1)
-        if flag == 1 {
-            calculationHistory = []
-            // Clear the LSB (first bit)
-            stateController?.convValues.clearLocalHistory &= 6
-        }
-        
-        //Set calculator text colour
-        setupCalculatorTextColour(state: stateController?.convValues.setCalculatorTextColour ?? false, colourToSet: stateController?.convValues.colour ?? UIColor.systemGreen)
-        
+
         updateOutputLabel(value: decimalLabelText ?? "0")
+        setupCommonViewWillAppear()
     }
-    
-    // iPad support is for portrait and landscape mode, need to alter constraints on device rotation
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        
-        // Deactivate current contraints and remove them from the list, new constraints will be calculated and activated as device rotates
-        if (UIDevice.current.userInterfaceIdiom == .pad) {
-            NSLayoutConstraint.deactivate(currentConstraints)
-            currentConstraints.removeAll()
-        }
-    }
-    
-    @objc func labelSingleTapped(_ sender: UITapGestureRecognizer) {
-        // Only perform action on single tap if user has that setting option enabled
-        if (stateController?.convValues.copyActionIndex == 0 || stateController?.convValues.pasteActionIndex == 0) {
-            // Decide which actions should be performed by a single tap
-            if (stateController?.convValues.copyActionIndex == 0 && stateController?.convValues.pasteActionIndex == 0) {
-                self.copyAndPasteSelected()
-            }
-            else if (stateController?.convValues.copyActionIndex == 0) {
-                self.copySelected()
-            }
-            else {
-                self.pasteSelected()
-            }
-        }
-    }
-    
-    @objc func labelDoubleTapped(_ sender: UILongPressGestureRecognizer) {
-        // Only perform action on double tap if user has that setting option enabled
-        if (stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) {
-            // Decide which actions should be performed by a double tap
-            if (stateController?.convValues.copyActionIndex == 1 && stateController?.convValues.pasteActionIndex == 1) {
-                self.copyAndPasteSelected()
-            }
-            else if (stateController?.convValues.copyActionIndex == 1) {
-                self.copySelected()
-            }
-            else {
-                self.pasteSelected()
-            }
-        }
-    }
-    
-    @objc func historyButtonTapped() {
-        presentHistory(calculationHistory: calculationHistory)
-    }
-    
-    func copySelected() {
-        var currentOutput = runningNumber;
-        if (runningNumber == ""){
-            let currLabel = outputLabel.text
-            let spacesRemoved = (currLabel?.components(separatedBy: ",").joined(separator: ""))!
-            currentOutput = spacesRemoved
-        }
 
-        let pasteboard = UIPasteboard.general
-        pasteboard.string = currentOutput
-        
-        //Alert the user that the output was copied to their clipboard
-        let alert = UIAlertController(title: "Copied to Clipboard", message: currentOutput + " has been added to your clipboard.", preferredStyle: .alert)
-        self.present(alert, animated: true, completion: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            alert.dismiss(animated: true, completion: nil)
-        }
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Copy)
-    }
-    
-    func pasteSelected() {
-        let alert = UIAlertController(title: "Paste from Clipboard", message: "Press confirm to paste the contents of your clipboard into HexaCalc.", preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "Confirm", style: .default, handler: {_ in self.pasteFromClipboardToDecimalCalculator()}))
-        alert.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
-        
-        self.present(alert, animated: true)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Paste)
-    }
-    
-    func copyAndPasteSelected() {
-        let alert = UIAlertController(title: "Select Clipboard Action", message: "Press the action that you would like to perform.", preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: {_ in self.copySelected()}))
-        alert.addAction(UIAlertAction(title: "Paste", style: .default, handler: {_ in self.pasteFromClipboardToDecimalCalculator()}))
-        
-        self.present(alert, animated: true)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.CopyAndPaste)
-    }
-    
-    //Function to get and format content from clipboard
-    func pasteFromClipboardToDecimalCalculator() {
-        var pastedInput = ""
-        let pasteboard = UIPasteboard.general
-        pastedInput = pasteboard.string ?? "0"
-        var isNegative = false
-        
-        //Validate input is a hexadecimal value
-        if (pastedInput.first == "-") {
-            isNegative = true
-            pastedInput.removeFirst()
-        }
-        let chars = CharacterSet(charactersIn: "0123456789.").inverted
-        let isValidDecimal = (pastedInput.uppercased().rangeOfCharacter(from: chars) == nil) && ((pastedInput.filter {$0 == "."}.count) < 2)
-        if (isValidDecimal && pastedInput.count < 308) {
-            if (pastedInput == "0") {
-                runningNumber = ""
-                leftValue = ""
-                rightValue = ""
-                result = ""
-                updateOutputLabel(value: "0")
-                stateController?.convValues.largerThan64Bits = false
-                stateController?.convValues.decimalVal = "0"
-                stateController?.convValues.hexVal = "0"
-                stateController?.convValues.binVal = "0"
-            }
-            else {
-                if (isNegative) {
-                    pastedInput = "-" + pastedInput
-                }
-                if (Double(pastedInput)! > 999999999 || Double(pastedInput)! < -999999999){
-                    //Need to use scientific notation for this
-                    runningNumber = pastedInput
-                    updateOutputLabel(value: "\(Double(pastedInput)!.scientificFormatted)")
-                    quickUpdateStateController()
-                }
-                else {
-                    if(Double(pastedInput)!.truncatingRemainder(dividingBy: 1) == 0) {
-                        runningNumber = "\(Int(Double(pastedInput)!))"
-                        updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
-                    }
-                    else {
-                        if (pastedInput.count > 9){
-                            //Need to round to 9 digits
-                            //First find how many digits the decimal portion is
-                            var num = Double(pastedInput)!
-                            if (num < 0){
-                                num *= -1
-                            }
-                            var counter = 1
-                            while (num > 1){
-                                counter *= 10
-                                num = num/10
-                            }
-                            var roundVal = 0
-                            if (counter == 1){
-                                roundVal = 100000000/(counter)
-                            }
-                            else {
-                                roundVal = 1000000000/(counter)
-                            }
-                            runningNumber = "\(Double(round(Double(roundVal) * Double(pastedInput)!)/Double(roundVal)))"
-                        }
-                        else {
-                            runningNumber = pastedInput
-                        }
-                    }
-                    updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
-                    quickUpdateStateController()
-                }
-            }
-        }
-        else {
-            var alertMessage = "Your clipboad did not contain a valid decimal string."
-            if (isValidDecimal) {
-                alertMessage = "The decimal string in your clipboard is too large."
-            }
-            //Alert the user why the paste failed
-            let alert = UIAlertController(title: "Paste Failed", message: alertMessage, preferredStyle: .alert)
-
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            
-            self.present(alert, animated: true)
-        }
-    }
-    
-    //Function to handle a swipe
-    @objc func handleLabelSwipes(_ sender:UISwipeGestureRecognizer) {
-        
-        //Make sure the label was swiped
-        guard (sender.view as? UILabel) != nil else { return }
-        
-        if (sender.direction == .left || sender.direction == .right) {
-            deletePressed(DELBtn)
-            telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.DeleteSwipe)
-        }
-    }
-    
-    //Function for setting up output label gesture recognizers
-    func setupOutputLabelGestureRecognizers() {
-        let labelSingleTap = UITapGestureRecognizer(target: self, action: #selector(self.labelSingleTapped(_:)))
-        labelSingleTap.numberOfTapsRequired = 1
-        let labelDoubleTap = UITapGestureRecognizer(target: self, action: #selector(self.labelDoubleTapped(_:)))
-        labelDoubleTap.numberOfTapsRequired = 2
-        let leftSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
-        let rightSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
-            
-        leftSwipe.direction = .left
-        rightSwipe.direction = .right
-
-        self.outputLabel.addGestureRecognizer(leftSwipe)
-        self.outputLabel.addGestureRecognizer(rightSwipe)
-        self.outputLabel.isUserInteractionEnabled = true
-        self.outputLabel.addGestureRecognizer(labelSingleTap)
-        self.outputLabel.addGestureRecognizer(labelDoubleTap)
-        
-        currentlyRecognizingDoubleTap = false
-        
-        // Small optimization to only delay single tap if absolutely necessary
-        if (stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) {
-            labelSingleTap.require(toFail: labelDoubleTap)
-            currentlyRecognizingDoubleTap = true
-        }
-    }
-    
     //MARK: Button Actions
     @IBAction func numberPressed(_ sender: RoundButton) {
-        
-        //Limit number of digits to 9
+
         var currentCopy = runningNumber
         var isNegative = false
         if (runningNumber != "" && currentCopy.removeFirst() == "-") {
             isNegative = true
         }
-        
+
         if ((runningNumber.count <= 8) || (runningNumber.count == 9 && isNegative)) {
             let digit = "\(sender.tag)"
-            if ((digit == "0") && (outputLabel.text == "0")){
+            if ((digit == "0") && (outputLabel.text == "0")) {
                 //if 0 is pressed and calculator is showing 0 then do nothing
             }
             else {
-                // Overwrite running number if it is already 0
                 if (runningNumber == "0") {
                     runningNumber = "\(sender.tag)"
                 }
@@ -432,12 +179,12 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                 }
                 updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
             }
-            
+
             stateController?.convValues.largerThan64Bits = false
             quickUpdateStateController()
         }
     }
-    
+
     @IBAction func allClearPressed(_ sender: RoundButton) {
         runningNumber = ""
         leftValue = ""
@@ -445,48 +192,44 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
         result = ""
         currentOperation = .NULL
         updateOutputLabel(value: "0")
-        
+
         stateController?.convValues.largerThan64Bits = false
         stateController?.convValues.decimalVal = "0"
         stateController?.convValues.hexVal = "0"
         stateController?.convValues.binVal = "0"
     }
-    
+
     @IBAction func secondFunctionPressed(_ sender: RoundButton) {
         let operatorButtons = [DIVBtn, MULTBtn, SUBBtn, PLUSBtn]
-        
+
         if (self.secondFunctionMode) {
-            // Change back to default operators
             self.changeOperators(buttons: operatorButtons, secondFunctionActive: false)
             SecondFunctionBtn.backgroundColor = .lightGray
         }
         else {
-            // Change to second function operators
             self.changeOperators(buttons: operatorButtons, secondFunctionActive: true)
             SecondFunctionBtn.backgroundColor = .white
         }
-        
+
         self.secondFunctionMode.toggle()
-        
+
         telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Second)
     }
-    
+
     @IBAction func deletePressed(_ sender: RoundButton) {
-        
-        // Do not delete anything if the calculator is displaying a number in scientific notation
+
         if (runningNumber.contains("e")) {
             return
         }
-        
+
         if (runningNumber.count == 0 || abs(Int(runningNumber) ?? 0) > 999999999) {
             //Nothing to delete
         }
         else {
-            //Need to set label to 0 when we remove last digit
             if (runningNumber.count == 1 || ((runningNumber.first == "-") && (runningNumber.count == 2)) || (runningNumber == "0.")){
                 runningNumber = ""
                 updateOutputLabel(value: "0")
-                
+
                 stateController?.convValues.largerThan64Bits = false
                 stateController?.convValues.binVal = "0"
                 stateController?.convValues.hexVal = "0"
@@ -499,17 +242,15 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             }
         }
     }
-    
+
     @IBAction func dotPressed(_ sender: RoundButton) {
-        
-        // Do not allow a dot to be added if the calculator is displaying a number in scientific notation
+
         if (runningNumber.contains("e")) {
             return
         }
-        
-        //Last character cannot be a dot
+
         if runningNumber.count <= 7 && !runningNumber.contains(".") {
-            if (outputLabel.text == "0" || runningNumber == ""){
+            if (outputLabel.text == "0" || runningNumber == "") {
                 runningNumber = ""
                 runningNumber = "0."
                 updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
@@ -518,57 +259,44 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                 runningNumber += "."
                 updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
             }
-            
+
             stateController?.convValues.largerThan64Bits = false
             quickUpdateStateController()
-            
         }
     }
-    
+
     @IBAction func equalsPressed(_ sender: RoundButton) {
         operation(operation: currentOperation)
-        
+
         telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
-        
-        // Completing calculation is a review worthy action
         ReviewManager.incrementReviewWorthyCount()
     }
-    
+
     @IBAction func plusPressed(_ sender: RoundButton) {
         if secondFunctionMode {
             // Squareroot pressed
             if (outputLabel.text == "0" || runningNumber == "") {
-                if (outputLabel.text != "0"){
-
-                    //Need to reset the current operation as we are overriding a null running number state
+                if (outputLabel.text != "0") {
                     currentOperation = .NULL
-
                     let currLabel = outputLabel.text
                     let commasRemoved = (currLabel?.components(separatedBy: ",").joined(separator: ""))!
-
                     let currentNumber = Double(commasRemoved)!
-                    
-                    // Error - cannot squareroot a negative number
+
                     if (currentNumber < 0.0) {
                         result = "Error!"
                         updateOutputLabel(value: result)
                         return
                     }
-                    
-                    result = "\(sqrt(currentNumber))"
 
+                    result = "\(sqrt(currentNumber))"
                     setupStateControllerValues()
                     stateController?.convValues.largerThan64Bits = false
-                    
-                    if (Double(result)! > 999999999){
-                        // Add to calculation history
+
+                    if (Double(result)! > 999999999) {
                         let unaryCalculationResult = result == "" ? "0" : result
                         let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
                         calculationHistory.insert(calculationData, at: 0)
-                        
                         leftValue = result
-                        
-                        // Need to use scientific notation for this
                         result = "\(Double(result)!.scientificFormatted)"
                         updateOutputLabel(value: result)
                         runningNumber = result
@@ -577,14 +305,11 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                     }
                     formatResult()
                     runningNumber = result
-                    
-                    // Add to calculation history
+
                     let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
                     let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
                     calculationHistory.insert(calculationData, at: 0)
-                    
                     leftValue = result
-                    
                     quickUpdateStateController()
                 }
                 else {
@@ -594,18 +319,16 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             }
             else {
                 let number = Double(runningNumber)!
-                
-                // Error - cannot squareroot a negative number
+
                 if (number < 0.0) {
                     result = "Error!"
                     updateOutputLabel(value: result)
                     return
                 }
-                
+
                 result = "\(sqrt(number))"
-                
-                //Cannot convert to binary or hexadecimal in this case -- overflow
-                if (Double(result)! >= Double(INT64_MAX) || Double(result)! <= Double((INT64_MAX * -1) - 1)){
+
+                if (Double(result)! >= Double(INT64_MAX) || Double(result)! <= Double((INT64_MAX * -1) - 1)) {
                     stateController?.convValues.largerThan64Bits = true
                     stateController?.convValues.decimalVal = result
                     stateController?.convValues.binVal = "0"
@@ -615,16 +338,12 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                     setupStateControllerValues()
                     stateController?.convValues.largerThan64Bits = false
                 }
-                
-                if (Double(result)! > 999999999){
-                    // Add to calculation history
+
+                if (Double(result)! > 999999999) {
                     let unaryCalculationResult = result == "" ? "0" : result
                     let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
                     calculationHistory.insert(calculationData, at: 0)
-                    
                     leftValue = result
-                    
-                    //Need to use scientific notation for this
                     result = "\(Double(result)!.scientificFormatted)"
                     updateOutputLabel(value: result)
                     runningNumber = result
@@ -633,14 +352,11 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                 }
                 formatResult()
                 runningNumber = result
-                
-                // Add to calculation history
+
                 let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
                 let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
                 calculationHistory.insert(calculationData, at: 0)
-                
                 leftValue = result
-                
                 quickUpdateStateController()
             }
         }
@@ -648,7 +364,7 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             operation(operation: .Add)
         }
     }
-    
+
     @IBAction func minusPressed(_ sender: RoundButton) {
         if secondFunctionMode {
             operation(operation: .Exp)
@@ -657,7 +373,7 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             operation(operation: .Subtract)
         }
     }
-    
+
     @IBAction func multiplyPressed(_ sender: RoundButton) {
         if secondFunctionMode {
             operation(operation: .Modulus)
@@ -666,26 +382,19 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             operation(operation: .Multiply)
         }
     }
-    
+
     @IBAction func dividePressed(_ sender: RoundButton) {
         if secondFunctionMode {
             // Plus/Minus pressed
-            // Essentially need to multiply the number by -1
-            if (outputLabel.text == "0" || runningNumber == ""){
-                //In the case that we want to negate the currently displayed number after a calculation
-                if (outputLabel.text != "0"){
-
-                    //Need to reset the current operation as we are overriding a null running number state
+            if (outputLabel.text == "0" || runningNumber == "") {
+                if (outputLabel.text != "0") {
                     currentOperation = .NULL
-
                     let currLabel = outputLabel.text
                     let commasRemoved = (currLabel?.components(separatedBy: ",").joined(separator: ""))!
-
                     var currentNumber = Double(commasRemoved)!
                     currentNumber *= -1
 
-                    //Find out if number is an integer
-                    if((currentNumber).truncatingRemainder(dividingBy: 1) == 0 && !(Double(commasRemoved)! >= Double(INT64_MAX) || Double(commasRemoved)! <= Double((INT64_MAX * -1) - 1))) {
+                    if ((currentNumber).truncatingRemainder(dividingBy: 1) == 0 && !(Double(commasRemoved)! >= Double(INT64_MAX) || Double(commasRemoved)! <= Double((INT64_MAX * -1) - 1))) {
                         runningNumber = "\(Int(currentNumber))"
                     }
                     else {
@@ -709,8 +418,7 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                 var number = Double(runningNumber)!
                 number *= -1
 
-                //Find out if number is an integer
-                if((number).truncatingRemainder(dividingBy: 1) == 0 && !(Double(runningNumber)! >= Double(INT64_MAX) || Double(runningNumber)! <= Double((INT64_MAX * -1) - 1))) {
+                if ((number).truncatingRemainder(dividingBy: 1) == 0 && !(Double(runningNumber)! >= Double(INT64_MAX) || Double(runningNumber)! <= Double((INT64_MAX * -1) - 1))) {
                     runningNumber = "\(Int(number))"
                 }
                 else {
@@ -730,30 +438,27 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             operation(operation: .Divide)
         }
     }
-    
+
     //MARK: Private Functions
-    
+
     private func operation(operation: Operation) {
-    
+
         if currentOperation != .NULL {
             if runningNumber != "" {
                 rightValue = runningNumber
                 runningNumber = ""
-                
-               
-                
+
                 switch (currentOperation) {
                 case .Add:
                     result = "\(Double(leftValue)! + Double(rightValue)!)"
-                    
+
                 case .Subtract:
-                result = "\(Double(leftValue)! - Double(rightValue)!)"
-                    
+                    result = "\(Double(leftValue)! - Double(rightValue)!)"
+
                 case .Multiply:
                     result = "\(Double(leftValue)! * Double(rightValue)!)"
-                    
+
                 case .Modulus:
-                    //Output Error! if division by 0
                     if Double(rightValue)! == 0.0 {
                         result = "Error!"
                         updateOutputLabel(value: result)
@@ -763,12 +468,11 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                     else {
                         result = "\(Double(leftValue)!.truncatingRemainder(dividingBy: Double(rightValue)!))"
                     }
-                    
+
                 case .Exp:
                     result = "\(pow(Double(leftValue)!, Double(rightValue)!))"
 
                 case .Divide:
-                    //Output Error! if division by 0
                     if Double(rightValue)! == 0.0 {
                         result = "Error!"
                         updateOutputLabel(value: result)
@@ -778,20 +482,17 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                     else {
                         result = "\(Double(leftValue)! / Double(rightValue)!)"
                     }
-                    
-                //Should not occur
+
                 default:
                     fatalError("Unexpected Operation...")
                 }
-                
-                // Create calculation data to add to history of calculations
+
                 let calculationData = CalculationData(leftValue: leftValue, rightValue: rightValue, operation: currentOperation, result: result, isUnaryOperation: false)
                 calculationHistory.insert(calculationData, at: 0)
-                
+
                 leftValue = result
-                
-                //Cannot convert to binary or hexadecimal in this case -- overflow
-                if (Double(result)! >= Double(INT64_MAX) || Double(result)! <= Double((INT64_MAX * -1) - 1)){
+
+                if (Double(result)! >= Double(INT64_MAX) || Double(result)! <= Double((INT64_MAX * -1) - 1)) {
                     stateController?.convValues.largerThan64Bits = true
                     stateController?.convValues.decimalVal = result
                     stateController?.convValues.binVal = "0"
@@ -801,9 +502,8 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                     setupStateControllerValues()
                     stateController?.convValues.largerThan64Bits = false
                 }
-                
-                if (Double(result)! > 999999999 || Double(result)! < -999999999){
-                    //Need to use scientific notation for this
+
+                if (Double(result)! > 999999999 || Double(result)! < -999999999) {
                     result = "\(Double(result)!.scientificFormatted)"
                     updateOutputLabel(value: result)
                     currentOperation = operation
@@ -811,11 +511,10 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
                 }
                 formatResult()
             }
-            
+
             currentOperation = operation
         }
         else {
-            //If string is empty it should be interpreted as a 0
             if runningNumber == "" {
                 if (leftValue == "") {
                     leftValue = "0"
@@ -828,42 +527,35 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             currentOperation = operation
         }
     }
-    
-    //Used to round and choose double or int representation
-    private func formatResult(){
-        //Find out if result is an integer
-        if(Double(result)!.truncatingRemainder(dividingBy: 1) == 0) {
+
+    private func formatResult() {
+        if (Double(result)!.truncatingRemainder(dividingBy: 1) == 0) {
             if Double(result)! >= Double(Int.max) || Double(result)! <= Double(Int.min) {
                 //Cannot convert to integer in this case
             }
             else {
                 result = "\(Int(Double(result)!))"
             }
-            
             updateOutputLabel(value: self.formatDecimalString(stringToConvert: result))
         }
         else {
             if (result.count > 9 && !result.contains("e")) {
-                //Need to round to 9 digits
-                //First find how many digits the decimal portion is
                 var num = Double(result)!
-                if (num < 0){
-                    num *= -1
-                }
+                if (num < 0) { num *= -1 }
                 var counter = 1
-                while (num > 1){
+                while (num > 1) {
                     counter *= 10
                     num = num/10
                 }
                 var roundVal = 0
-                if (counter == 1){
+                if (counter == 1) {
                     roundVal = 100000000/(counter)
                 }
                 else {
                     roundVal = 1000000000/(counter)
                 }
                 let roundedResult = "\(Double(round(Double(roundVal) * Double(result)!)/Double(roundVal)))"
-                
+
                 let decimalComponents = roundedResult.components(separatedBy: ".")
                 if (decimalComponents.count == 2) {
                     let chars = CharacterSet(charactersIn: "0.").inverted
@@ -887,8 +579,7 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             }
         }
     }
-    
-    //Perform a full state controller update when a new result is calculated via an operation key
+
     private func setupStateControllerValues() {
         stateController?.convValues.largerThan64Bits = false
         stateController?.convValues.decimalVal = result
@@ -897,18 +588,12 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
         stateController?.convValues.hexVal = hexConversion
         stateController?.convValues.binVal = binConversion
     }
-    
-    //Perform a quick update to keep the state controller variables in sync with the calculator label
+
     private func quickUpdateStateController() {
-        //Safety condition in the case that runningNumber is nil
-        if (runningNumber == ""){
-            return
-        }
-        //Need to keep the state controller updated with what is on the screen
+        if (runningNumber == "") { return }
         stateController?.convValues.decimalVal = runningNumber
-        
-        //Cannot convert to binary or hexadecimal in this case -- overflow
-        if (Double(runningNumber)! >= Double(INT64_MAX) || Double(runningNumber)! <= Double((INT64_MAX * -1) - 1)){
+
+        if (Double(runningNumber)! >= Double(INT64_MAX) || Double(runningNumber)! <= Double((INT64_MAX * -1) - 1)) {
             stateController?.convValues.largerThan64Bits = true
             stateController?.convValues.binVal = "0"
             stateController?.convValues.hexVal = "0"
@@ -920,13 +605,12 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
             stateController?.convValues.binVal = binCurrentVal
         }
     }
-    
-    // Add standard comma separation that the stock iOS calculator has
+
     func formatDecimalString(stringToConvert: String) -> String {
         if (stringToConvert.contains("e")) {
             return stringToConvert
         }
-        
+
         var stringToManipulate = stringToConvert
         var stringCopy1 = stringToConvert
         var stringCopy2 = stringToConvert
@@ -959,63 +643,105 @@ class DecimalViewController: UIViewController, HistoryButtonHost {
         }
         return stringToReturn
     }
-    
-    //Function to check whether the user wants the output text label colour to be the same as the overall theme
-    private func setupCalculatorTextColour(state: Bool, colourToSet: UIColor){
-        if (state) {
-            outputLabel.textColor = colourToSet
-        }
-        else {
-            outputLabel.textColor = UIColor.white
-        }
-    }
-    
-    // Used to change the display text of buttons for second function mode
+
     private func changeOperators(buttons: [RoundButton?], secondFunctionActive: Bool) {
         if secondFunctionActive {
             for (i, button) in buttons.enumerated() {
                 switch i {
-                case 0:
-                    button?.setTitle("±", for: .normal)
-                case 1:
-                    button?.setTitle("MOD", for: .normal)
-                case 2:
-                    button?.setTitle("xʸ", for: .normal)
-                case 3:
-                    button?.setTitle("√", for: .normal)
-                default:
-                    fatalError("Index out of range")
+                case 0: button?.setTitle("±", for: .normal)
+                case 1: button?.setTitle("MOD", for: .normal)
+                case 2: button?.setTitle("xʸ", for: .normal)
+                case 3: button?.setTitle("√", for: .normal)
+                default: fatalError("Index out of range")
                 }
             }
         }
         else {
             for (i, button) in buttons.enumerated() {
                 switch i {
-                case 0:
-                    button?.setTitle("÷", for: .normal)
-                case 1:
-                    button?.setTitle("×", for: .normal)
-                case 2:
-                    button?.setTitle("-", for: .normal)
-                case 3:
-                    button?.setTitle("+", for: .normal)
-                default:
-                    fatalError("Index out of range")
+                case 0: button?.setTitle("÷", for: .normal)
+                case 1: button?.setTitle("×", for: .normal)
+                case 2: button?.setTitle("-", for: .normal)
+                case 3: button?.setTitle("+", for: .normal)
+                default: fatalError("Index out of range")
                 }
             }
         }
     }
-    
-    // Standardized function to update the output label
-    private func updateOutputLabel(value: String) {
-        outputLabel.text = value
-        outputLabel.accessibilityLabel = value
-    }
-}
 
-//Adds state controller to the view controller
-extension DecimalViewController: StateControllerProtocol {
-  func setState(state: StateController) {
-    self.stateController = state
-  }
+    private func pasteFromClipboardToDecimalCalculator() {
+        var pastedInput = ""
+        let pasteboard = UIPasteboard.general
+        pastedInput = pasteboard.string ?? "0"
+        var isNegative = false
+
+        if (pastedInput.first == "-") {
+            isNegative = true
+            pastedInput.removeFirst()
+        }
+        let chars = CharacterSet(charactersIn: "0123456789.").inverted
+        let isValidDecimal = (pastedInput.uppercased().rangeOfCharacter(from: chars) == nil) && ((pastedInput.filter {$0 == "."}.count) < 2)
+        if (isValidDecimal && pastedInput.count < 308) {
+            if (pastedInput == "0") {
+                runningNumber = ""
+                leftValue = ""
+                rightValue = ""
+                result = ""
+                updateOutputLabel(value: "0")
+                stateController?.convValues.largerThan64Bits = false
+                stateController?.convValues.decimalVal = "0"
+                stateController?.convValues.hexVal = "0"
+                stateController?.convValues.binVal = "0"
+            }
+            else {
+                if (isNegative) {
+                    pastedInput = "-" + pastedInput
+                }
+                if (Double(pastedInput)! > 999999999 || Double(pastedInput)! < -999999999) {
+                    runningNumber = pastedInput
+                    updateOutputLabel(value: "\(Double(pastedInput)!.scientificFormatted)")
+                    quickUpdateStateController()
+                }
+                else {
+                    if (Double(pastedInput)!.truncatingRemainder(dividingBy: 1) == 0) {
+                        runningNumber = "\(Int(Double(pastedInput)!))"
+                        updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
+                    }
+                    else {
+                        if (pastedInput.count > 9) {
+                            var num = Double(pastedInput)!
+                            if (num < 0) { num *= -1 }
+                            var counter = 1
+                            while (num > 1) {
+                                counter *= 10
+                                num = num/10
+                            }
+                            var roundVal = 0
+                            if (counter == 1) {
+                                roundVal = 100000000/(counter)
+                            }
+                            else {
+                                roundVal = 1000000000/(counter)
+                            }
+                            runningNumber = "\(Double(round(Double(roundVal) * Double(pastedInput)!)/Double(roundVal)))"
+                        }
+                        else {
+                            runningNumber = pastedInput
+                        }
+                    }
+                    updateOutputLabel(value: self.formatDecimalString(stringToConvert: runningNumber))
+                    quickUpdateStateController()
+                }
+            }
+        }
+        else {
+            var alertMessage = "Your clipboad did not contain a valid decimal string."
+            if (isValidDecimal) {
+                alertMessage = "The decimal string in your clipboard is too large."
+            }
+            let alert = UIAlertController(title: "Paste Failed", message: alertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true)
+        }
+    }
 }

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -8,13 +8,9 @@
 
 import UIKit
 
-class HexadecimalViewController: UIViewController, HistoryButtonHost {
+class HexadecimalViewController: CalculatorViewController {
 
-    
     //MARK: Properties
-    var stateController: StateController?
-    
-    @IBOutlet weak var outputLabel: UILabel!
     @IBOutlet weak var hexVStack: UIStackView!
     @IBOutlet weak var hexHStack1: UIStackView!
     @IBOutlet weak var hexHStack2: UIStackView!
@@ -22,7 +18,7 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
     @IBOutlet weak var hexHStack4: UIStackView!
     @IBOutlet weak var hexHStack5: UIStackView!
     @IBOutlet weak var hexHStack6: UIStackView!
-    
+
     @IBOutlet weak var ACBtn: RoundButton!
     @IBOutlet weak var DELBtn: RoundButton!
     @IBOutlet weak var SecondFunctionBtn: RoundButton!
@@ -51,102 +47,103 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
     @IBOutlet weak var Btn2: RoundButton!
     @IBOutlet weak var Btn3: RoundButton!
     @IBOutlet weak var EQUALSBtn: RoundButton!
-    
-    // Programmatic UIButton
-    var historyButton: UIButton!
-    var historyButtonWidthConstraint: NSLayoutConstraint?
-    
+
     //MARK: Variables
-    var runningNumber = ""
-    var leftValue = ""
     var leftValueHex = ""
-    var rightValue = ""
-    // Values used to store calculation history
     var leftHexValue = ""
     var rightHexValue = ""
-    var result = ""
-    
-    var currentOperation:Operation = .NULL
-    
-    // Current contraints are stored for the iPad such that rotating the screen allows constraints to be replaced
-    var currentConstraints: [NSLayoutConstraint] = []
-    
-    var currentlyRecognizingDoubleTap = false
-    
+
     var secondFunctionMode = false
 
-    var calculationHistory: [CalculationData] = []
-    
-    // Access singleton TelemetryManager class object
-    let telemetryManager = TelemetryManager.sharedTelemetryManager
-    let telemetryTab = TelemetryTab.Hexadecimal
-    
+    // MARK: Abstract overrides
+
+    override var telemetryTab: TelemetryTab { .Hexadecimal }
+    override var historyFlagReadMask: Int32 { 4 }
+    override var historyFlagShift: Int32 { 2 }
+    override var historyFlagClearMask: Int32 { 3 }
+
+    override func deleteLastDigit() {
+        deletePressed(DELBtn)
+    }
+
+    override func pasteFromClipboard() {
+        pasteFromClipboardToHexadecimalCalculator()
+    }
+
+    override func copyTextFromLabel() -> String {
+        if runningNumber == "" {
+            return outputLabel.text ?? "0"
+        }
+        return runningNumber
+    }
+
+    override func updateThemeColour(_ colour: UIColor) {
+        PLUSBtn.backgroundColor = colour
+        SUBBtn.backgroundColor = colour
+        MULTBtn.backgroundColor = colour
+        DIVBtn.backgroundColor = colour
+        EQUALSBtn.backgroundColor = colour
+        outputLabel.textColor = colour
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         outputLabel.accessibilityIdentifier = "Hexadecimal Output Label"
         updateOutputLabel(value: "0")
-        
+
         // convValues is pre-populated by HexaCalcTabBarController.viewDidLoad before any child VC loads
         if let colour = stateController?.convValues.colour {
-            PLUSBtn.backgroundColor = colour
-            SUBBtn.backgroundColor = colour
-            MULTBtn.backgroundColor = colour
-            DIVBtn.backgroundColor = colour
-            EQUALSBtn.backgroundColor = colour
+            updateThemeColour(colour)
         }
         setupCalculatorTextColour(
             state: stateController?.convValues.setCalculatorTextColour ?? false,
             colourToSet: stateController?.convValues.colour ?? .systemGreen
         )
 
-        //Setup gesture recognizers
-        self.setupOutputLabelGestureRecognizers()
-        
-        // Force light mode to be used (for now) - to hide the navigation bar line
+        setupOutputLabelGestureRecognizers()
         overrideUserInterfaceStyle = .light
-        
+
         if #available(iOS 17.0, *) {
             traitOverrides.horizontalSizeClass = .compact
         }
-        
+
         ReviewManager.requestReviewIfAppropriate()
     }
-    
+
     override func viewDidLayoutSubviews() {
-        // Setup Hexadecimal View Controller constraints
         let screenWidth = view.bounds.width
         let screenHeight = view.bounds.height
-        
+
         let hStacks = [hexHStack1!, hexHStack2!, hexHStack3!, hexHStack4!, hexHStack5!, hexHStack6!]
         let singleButtons = [XORBtn!, ORBtn!, ANDBtn!, NOTBtn!, DIVBtn!, MULTBtn!, SUBBtn!, PLUSBtn!, EQUALSBtn!,
                              Btn0!, Btn1!, Btn2!, Btn3!, Btn4!, Btn5!, Btn6!, Btn7!, Btn8!, Btn9!,
                              ABtn!, BBtn!, CBtn!, DBtn!, EBtn!, FBtn!, SecondFunctionBtn!]
         let doubleButtons = [ACBtn!, DELBtn!]
-        
-        if (UIDevice.current.userInterfaceIdiom == .pad) {
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
             let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: hexVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
             currentConstraints.append(contentsOf: stackConstraints)
-            
+
             let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
             currentConstraints.append(contentsOf: buttonConstraints)
-            
+
             let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
             currentConstraints.append(contentsOf: labelConstraints)
-            
+
             NSLayoutConstraint.activate(currentConstraints)
         }
         else {
             let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: hexVStack, outputLabel: outputLabel, screenWidth: screenWidth)
             NSLayoutConstraint.activate(stackConstraints)
-            
+
             let buttonConstraints = UIHelper.setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: 1)
             NSLayoutConstraint.activate(buttonConstraints)
-            
+
             let labelConstraints = UIHelper.setupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, calculator: 1)
             NSLayoutConstraint.activate(labelConstraints)
         }
     }
+
     // Load the current converted value from either of the other calculator screens
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -157,8 +154,8 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
         }
         else {
             var newLabelValue = stateController?.convValues.hexVal.uppercased()
-            
-            if (newLabelValue == "0"){
+
+            if (newLabelValue == "0") {
                 updateOutputLabel(value: "0")
                 runningNumber = ""
                 leftValue = ""
@@ -167,8 +164,7 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
                 currentOperation = .NULL
             }
             else {
-                //Need special case to convert negative values
-                if (newLabelValue!.contains("-")){
+                if (newLabelValue!.contains("-")) {
                     newLabelValue = formatNegativeHex(hexToConvert: newLabelValue ?? "0").uppercased()
                 }
                 runningNumber = newLabelValue ?? "0"
@@ -176,140 +172,517 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
                 updateOutputLabel(value: newLabelValue ?? "0")
             }
         }
-        
-        setupHistoryButton()
-        updateHistoryButton(stateController: stateController)
-        
-        //Set button colour based on state controller
-        if (stateController?.convValues.colour != nil){
-            PLUSBtn.backgroundColor = stateController?.convValues.colour
-            SUBBtn.backgroundColor = stateController?.convValues.colour
-            MULTBtn.backgroundColor = stateController?.convValues.colour
-            DIVBtn.backgroundColor = stateController?.convValues.colour
-            EQUALSBtn.backgroundColor = stateController?.convValues.colour
-            outputLabel.textColor = stateController?.convValues.colour
-            historyButton.tintColor = stateController?.convValues.colour
-        }
-        
-        // Small optimization to only delay single tap if absolutely necessary
-        if (((stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) && currentlyRecognizingDoubleTap == false) ||
-            ((stateController?.convValues.copyActionIndex != 1 && stateController?.convValues.pasteActionIndex != 1) && currentlyRecognizingDoubleTap == true)) {
-            outputLabel.gestureRecognizers?.forEach(outputLabel.removeGestureRecognizer)
-            self.setupOutputLabelGestureRecognizers()
-        }
-        
-        // Check if local history needs to be cleared (MSB of flag)
-        let flag = ((stateController?.convValues.clearLocalHistory ?? 0) & 4) >> 2
-        if flag == 1 {
-            calculationHistory = []
-            // Clear the MSB (third bit)
-            stateController?.convValues.clearLocalHistory &= 3
-        }
-        
-        //Set calculator text colour
-        setupCalculatorTextColour(state: stateController?.convValues.setCalculatorTextColour ?? false, colourToSet: stateController?.convValues.colour ?? UIColor.systemGreen)
-        
+
+        setupCommonViewWillAppear()
     }
-    
-    // iPad support is for portrait and landscape mode, need to alter constraints on device rotation
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        
-        // Deactivate current contraints and remove them from the list, new constraints will be calculated and activated as device rotates
-        if (UIDevice.current.userInterfaceIdiom == .pad) {
-            NSLayoutConstraint.deactivate(currentConstraints)
-            currentConstraints.removeAll()
-        }
+
+    //MARK: Button Actions
+    @IBAction func ACPressed(_ sender: RoundButton) {
+        runningNumber = ""
+        leftValue = ""
+        leftValueHex = ""
+        rightValue = ""
+        result = ""
+        currentOperation = .NULL
+        updateOutputLabel(value: "0")
+
+        stateController?.convValues.largerThan64Bits = false
+        stateController?.convValues.decimalVal = "0"
+        stateController?.convValues.hexVal = "0"
+        stateController?.convValues.binVal = "0"
     }
-    
-    @objc func labelSingleTapped(_ sender: UITapGestureRecognizer) {
-        // Only perform action on single tap if user has that setting option enabled
-        if (stateController?.convValues.copyActionIndex == 0 || stateController?.convValues.pasteActionIndex == 0) {
-            // Decide which actions should be performed by a single tap
-            if (stateController?.convValues.copyActionIndex == 0 && stateController?.convValues.pasteActionIndex == 0) {
-                self.copyAndPasteSelected()
+
+    @IBAction func deletePressed(_ sender: RoundButton) {
+        if (stateController?.convValues.largerThan64Bits == true) { return }
+
+        if (runningNumber != "0") {
+            if (runningNumber != "") {
+                runningNumber.removeLast()
+                if (runningNumber == "") {
+                    stateController?.convValues.largerThan64Bits = false
+                    stateController?.convValues.decimalVal = "0"
+                    stateController?.convValues.hexVal = "0"
+                    stateController?.convValues.binVal = "0"
+                    updateOutputLabel(value: "0")
+                }
+                else {
+                    updateOutputLabel(value: runningNumber)
+                    quickUpdateStateController()
+                }
             }
-            else if (stateController?.convValues.copyActionIndex == 0) {
-                self.copySelected()
+        }
+    }
+
+    @IBAction func secondFunctionPressed(_ sender: RoundButton) {
+        let operatorButtons = [DIVBtn, MULTBtn, SUBBtn, PLUSBtn]
+
+        if (self.secondFunctionMode) {
+            self.changeOperators(buttons: operatorButtons, secondFunctionActive: false)
+            SecondFunctionBtn.backgroundColor = .lightGray
+        }
+        else {
+            self.changeOperators(buttons: operatorButtons, secondFunctionActive: true)
+            SecondFunctionBtn.backgroundColor = .white
+        }
+
+        self.secondFunctionMode.toggle()
+
+        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Second)
+    }
+
+    @IBAction func digitPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) {
+            runningNumber = ""
+        }
+
+        if (runningNumber.count <= 15) {
+            let digit = "\(sender.tag)"
+            if ((digit == "0") && (outputLabel.text == "0")) {
+                //if 0 is pressed and calculator is showing 0 then do nothing
             }
             else {
-                self.pasteSelected()
+                let convertedDigit = tagToHex(digitToConvert: digit)
+                if (runningNumber == "0") {
+                    runningNumber = convertedDigit
+                }
+                else {
+                    runningNumber += convertedDigit
+                }
+                updateOutputLabel(value: runningNumber)
+                quickUpdateStateController()
             }
         }
     }
-    
-    @objc func labelDoubleTapped(_ sender: UILongPressGestureRecognizer) {
-        // Only perform action on double tap if user has that setting option enabled
-        if (stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) {
-            // Decide which actions should be performed by a double tap
-            if (stateController?.convValues.copyActionIndex == 1 && stateController?.convValues.pasteActionIndex == 1) {
-                self.copyAndPasteSelected()
+
+    @IBAction func XORPressed(_ sender: RoundButton) {
+        operation(operation: .XOR)
+    }
+
+    @IBAction func ORPressed(_ sender: RoundButton) {
+        operation(operation: .OR)
+    }
+
+    @IBAction func ANDPressed(_ sender: RoundButton) {
+        operation(operation: .AND)
+    }
+
+    @IBAction func NOTPressed(_ sender: RoundButton) {
+
+        if (stateController?.convValues.largerThan64Bits == true) { return }
+
+        var currentValue = runningNumber
+        if (runningNumber == "") {
+            currentValue = outputLabel.text ?? "0"
+        }
+
+        let castInt = UInt64(currentValue, radix: 16)!
+        let onesComplimentInt = ~castInt
+
+        runningNumber = String(onesComplimentInt, radix: 16).uppercased()
+        updateOutputLabel(value: runningNumber)
+
+        let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
+        let calculationData = CalculationData(leftValue: currentValue, rightValue: "", operation: .Not, result: unaryCalculationResult, isUnaryOperation: true)
+        calculationHistory.insert(calculationData, at: 0)
+
+        quickUpdateStateController()
+    }
+
+    @IBAction func dividePressed(_ sender: RoundButton) {
+        if secondFunctionMode {
+            // 2's complement pressed
+            if (stateController?.convValues.largerThan64Bits == true || runningNumber == "") { return }
+
+            let castInt = UInt64(runningNumber, radix: 16)!
+            let twosComplimentInt = ~castInt + 1
+
+            runningNumber = String(twosComplimentInt, radix: 16).uppercased()
+            updateOutputLabel(value: runningNumber)
+            quickUpdateStateController()
+        }
+        else {
+            operation(operation: .Divide)
+        }
+    }
+
+    @IBAction func multiplyPressed(_ sender: RoundButton) {
+        if secondFunctionMode {
+            operation(operation: .Modulus)
+        }
+        else {
+            operation(operation: .Multiply)
+        }
+    }
+
+    @IBAction func minusPressed(_ sender: RoundButton) {
+        if secondFunctionMode {
+            operation(operation: .LeftShift)
+        }
+        else {
+            operation(operation: .Subtract)
+        }
+    }
+
+    @IBAction func plusPressed(_ sender: RoundButton) {
+        if secondFunctionMode {
+            operation(operation: .RightShift)
+        }
+        else {
+            operation(operation: .Add)
+        }
+    }
+
+    @IBAction func equalsPressed(_ sender: RoundButton) {
+        operation(operation: currentOperation)
+
+        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
+        ReviewManager.incrementReviewWorthyCount()
+    }
+
+    //MARK: Private Functions
+
+    private func operation(operation: Operation) {
+
+        if currentOperation != .NULL {
+
+            if runningNumber != "" {
+                leftHexValue = runningNumber
             }
-            else if (stateController?.convValues.copyActionIndex == 1) {
-                self.copySelected()
+
+            let binRightValue = hexToBin(hexToConvert: runningNumber)
+            if binRightValue != "" {
+                if (binRightValue.first == "1" && binRightValue.count == 64) {
+                    rightValue = String(Int64(bitPattern: UInt64(binRightValue, radix: 2)!))
+                }
+                else {
+                    rightValue = String(Int(binRightValue, radix: 2)!)
+                }
+                runningNumber = ""
+
+                switch (currentOperation) {
+
+                case .Add:
+                    let overCheck = Int64(leftValue)!.addingReportingOverflow(Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! + Int(rightValue)!)"
+                    }
+
+                case .Subtract:
+                    let overCheck = Int64(leftValue)!.subtractingReportingOverflow(Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! - Int(rightValue)!)"
+                    }
+
+                case .Multiply:
+                    let overCheck = Int64(leftValue)!.multipliedReportingOverflow(by: Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! * Int(rightValue)!)"
+                    }
+
+                case .Modulus:
+                    if Int(rightValue)! == 0 {
+                        result = "Error!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        return
+                    }
+                    result = "\(Int(Double(leftValue)!.truncatingRemainder(dividingBy: Double(rightValue)!)))"
+
+                case .Divide:
+                    if Int(rightValue)! == 0 {
+                        result = "Error!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        return
+                    }
+                    let overCheck = Int64(leftValue)!.dividedReportingOverflow(by: Int64(rightValue)!)
+                    if (overCheck.overflow) {
+                        result = "Error! Integer Overflow!"
+                        updateOutputLabel(value: result)
+                        currentOperation = operation
+                        stateController?.convValues.largerThan64Bits = true
+                        stateController?.convValues.decimalVal = "0"
+                        return
+                    }
+                    else {
+                        result = "\(Int(leftValue)! / Int(rightValue)!)"
+                    }
+
+                case .LeftShift:
+                    result = "\(Int(leftValue)! << Int(rightValue)!)"
+
+                case .RightShift:
+                    let currValue = hexToBin(hexToConvert: leftValueHex)
+                    let rightShiftRight = Int(rightValue)!
+                    if (rightShiftRight <= 0) {
+                        result = leftValue
+                    }
+                    else if (rightShiftRight > currValue.count) {
+                        result = "0"
+                    }
+                    else {
+                        result = String(Int(UInt64(currValue.dropLast(rightShiftRight), radix: 2)!))
+                    }
+
+                case .AND:
+                    result = "\(Int(leftValue)! & Int(rightValue)!)"
+
+                case .OR:
+                    result = "\(Int(leftValue)! | Int(rightValue)!)"
+
+                case .XOR:
+                    result = "\(Int(leftValue)! ^ Int(rightValue)!)"
+
+                default:
+                    fatalError("Unexpected Operation...")
+                }
+
+                leftValue = result
+                setupStateControllerValues()
+
+                let hexRepresentation = stateController?.convValues.hexVal ?? "0"
+                var newLabelValue = hexRepresentation.uppercased()
+                leftValueHex = newLabelValue
+                if (hexRepresentation.contains("-")) {
+                    newLabelValue = formatNegativeHex(hexToConvert: newLabelValue).uppercased()
+                }
+                updateOutputLabel(value: newLabelValue)
+
+                let calculationData = CalculationData(leftValue: rightHexValue, rightValue: leftHexValue, operation: currentOperation, result: newLabelValue, isUnaryOperation: false)
+                calculationHistory.insert(calculationData, at: 0)
+
+                rightHexValue = newLabelValue
+            }
+            currentOperation = operation
+        }
+        else {
+            rightHexValue = runningNumber
+            let binLeftValue = hexToBin(hexToConvert: runningNumber)
+            if (runningNumber == "") {
+                if (leftValue == "") {
+                    leftValue = "0"
+                    leftValueHex = "0"
+                }
             }
             else {
-                self.pasteSelected()
+                leftValueHex = runningNumber
+                if (binLeftValue.first == "1" && binLeftValue.count == 64) {
+                    leftValue = String(Int64(bitPattern: UInt64(binLeftValue, radix: 2)!))
+                }
+                else {
+                    leftValue = String(Int(binLeftValue, radix: 2)!)
+                }
+            }
+            runningNumber = ""
+            currentOperation = operation
+        }
+    }
+
+    private func setupStateControllerValues() {
+        stateController?.convValues.decimalVal = result
+        let hexConversion = String(Int(result)!, radix: 16)
+        let binConversion = String(Int(result)!, radix: 2)
+        stateController?.convValues.hexVal = hexConversion
+        stateController?.convValues.binVal = binConversion
+    }
+
+    private func quickUpdateStateController() {
+
+        if (runningNumber.count < 17) {
+            stateController?.convValues.largerThan64Bits = false
+        }
+
+        stateController?.convValues.hexVal = runningNumber
+        var binCurrentVal = ""
+        var decCurrentVal = ""
+        if ((!outputLabel.text!.first!.isNumber || ((outputLabel.text!.first == "9") || (outputLabel.text!.first == "8"))) && (outputLabel.text!.count == 16)) {
+            var currentLabel = runningNumber
+            currentLabel = hexToBin(hexToConvert: currentLabel)
+            binCurrentVal = currentLabel
+            decCurrentVal = String(Int64(bitPattern: UInt64(currentLabel, radix: 2)!))
+        }
+        else {
+            binCurrentVal = String(Int(runningNumber, radix: 16)!, radix: 2)
+            decCurrentVal = String(Int(runningNumber, radix: 16)!)
+        }
+        stateController?.convValues.binVal = binCurrentVal
+        stateController?.convValues.decimalVal = decCurrentVal
+    }
+
+    private func tagToHex(digitToConvert: String) -> String {
+        var result = ""
+        if (Int(digitToConvert)! < 10) {
+            result = digitToConvert
+        }
+        else {
+            switch Int(digitToConvert)! {
+            case 10: result = "A"
+            case 11: result = "B"
+            case 12: result = "C"
+            case 13: result = "D"
+            case 14: result = "E"
+            case 15: result = "F"
+            default: break
+            }
+        }
+        return result
+    }
+
+    private func hexToBin(hexToConvert: String) -> String {
+        var result = ""
+        var copy = hexToConvert.uppercased()
+
+        if (hexToConvert == "") { return hexToConvert }
+
+        for _ in 0..<hexToConvert.count {
+            let currentDigit = copy.first
+            copy.removeFirst()
+
+            switch currentDigit {
+            case "0": result += "0000"
+            case "1": result += "0001"
+            case "2": result += "0010"
+            case "3": result += "0011"
+            case "4": result += "0100"
+            case "5": result += "0101"
+            case "6": result += "0110"
+            case "7": result += "0111"
+            case "8": result += "1000"
+            case "9": result += "1001"
+            case "A": result += "1010"
+            case "B": result += "1011"
+            case "C": result += "1100"
+            case "D": result += "1101"
+            case "E": result += "1110"
+            case "F": result += "1111"
+            default: fatalError("Unexpected Operation...")
+            }
+        }
+
+        return result
+    }
+
+    private func formatNegativeHex(hexToConvert: String) -> String {
+        var manipulatedString = hexToConvert
+        manipulatedString.removeFirst()
+
+        if (manipulatedString == "8000000000000000") {
+            return manipulatedString
+        }
+
+        let binaryInitial = String(Int(manipulatedString, radix: 16)!, radix: 2)
+        var invertedBinary = ""
+
+        for i in 0..<binaryInitial.count {
+            if (binaryInitial[binaryInitial.index(binaryInitial.startIndex, offsetBy: i)] == "0") {
+                invertedBinary += "1"
+            }
+            else {
+                invertedBinary += "0"
+            }
+        }
+
+        let index = invertedBinary.lastIndex(of: "0") ?? (invertedBinary.endIndex)
+        var newSubString = String(invertedBinary.prefix(upTo: index))
+
+        if (newSubString.count < invertedBinary.count) {
+            newSubString = newSubString + "1"
+        }
+        while (newSubString.count < invertedBinary.count) {
+            newSubString = newSubString + "0"
+        }
+        while (newSubString.count < 64) {
+            newSubString = "1" + newSubString
+        }
+
+        var hexResult = ""
+        for _ in 0..<16 {
+            let currentIndex = newSubString.index(newSubString.endIndex, offsetBy: -4)
+            let currentBinary = String(newSubString.suffix(from: currentIndex))
+            newSubString.removeLast(4)
+
+            switch currentBinary {
+            case "0000": hexResult = "0" + hexResult
+            case "0001": hexResult = "1" + hexResult
+            case "0010": hexResult = "2" + hexResult
+            case "0011": hexResult = "3" + hexResult
+            case "0100": hexResult = "4" + hexResult
+            case "0101": hexResult = "5" + hexResult
+            case "0110": hexResult = "6" + hexResult
+            case "0111": hexResult = "7" + hexResult
+            case "1000": hexResult = "8" + hexResult
+            case "1001": hexResult = "9" + hexResult
+            case "1010": hexResult = "a" + hexResult
+            case "1011": hexResult = "b" + hexResult
+            case "1100": hexResult = "c" + hexResult
+            case "1101": hexResult = "d" + hexResult
+            case "1110": hexResult = "e" + hexResult
+            case "1111": hexResult = "f" + hexResult
+            default: fatalError("Unexpected Operation...")
+            }
+        }
+
+        return hexResult
+    }
+
+    private func changeOperators(buttons: [RoundButton?], secondFunctionActive: Bool) {
+        if secondFunctionActive {
+            for (i, button) in buttons.enumerated() {
+                switch i {
+                case 0: button?.setTitle("2's", for: .normal)
+                case 1: button?.setTitle("MOD", for: .normal)
+                case 2: button?.setTitle("<<X", for: .normal)
+                case 3: button?.setTitle(">>X", for: .normal)
+                default: fatalError("Index out of range")
+                }
+            }
+        }
+        else {
+            for (i, button) in buttons.enumerated() {
+                switch i {
+                case 0: button?.setTitle("÷", for: .normal)
+                case 1: button?.setTitle("×", for: .normal)
+                case 2: button?.setTitle("-", for: .normal)
+                case 3: button?.setTitle("+", for: .normal)
+                default: fatalError("Index out of range")
+                }
             }
         }
     }
-    
-    @objc func historyButtonTapped() {
-        presentHistory(calculationHistory: calculationHistory)
-    }
-    
-    func copySelected() {
-        var currentOutput = runningNumber;
-        if (runningNumber == ""){
-            currentOutput = outputLabel.text ?? "0"
-        }
 
-        let pasteboard = UIPasteboard.general
-        pasteboard.string = currentOutput
-        
-        // Alert the user that the output was copied to their clipboard
-        let alert = UIAlertController(title: "Copied to Clipboard", message: currentOutput + " has been added to your clipboard.", preferredStyle: .alert)
-        self.present(alert, animated: true, completion: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            alert.dismiss(animated: true, completion: nil)
-        }
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Copy)
-    }
-    
-    func pasteSelected() {
-        let alert = UIAlertController(title: "Paste from Clipboard", message: "Press confirm to paste the contents of your clipboard into HexaCalc.", preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "Confirm", style: .default, handler: {_ in self.pasteFromClipboardToHexadecimalCalculator()}))
-        alert.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
-        
-        self.present(alert, animated: true)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Paste)
-    }
-    
-    func copyAndPasteSelected() {
-        let alert = UIAlertController(title: "Select Clipboard Action", message: "Press the action that you would like to perform.", preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "Copy", style: .default, handler: {_ in self.copySelected()}))
-        alert.addAction(UIAlertAction(title: "Paste", style: .default, handler: {_ in self.pasteFromClipboardToHexadecimalCalculator()}))
-        
-        self.present(alert, animated: true)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.CopyAndPaste)
-    }
-    
-    // Function to get and format content from clipboard
-    func pasteFromClipboardToHexadecimalCalculator() {
+    private func pasteFromClipboardToHexadecimalCalculator() {
         var pastedInput = ""
         let pasteboard = UIPasteboard.general
         pastedInput = pasteboard.string ?? "0"
-        
-        // Validate input is a hexadecimal value
+
         let chars = CharacterSet(charactersIn: "0123456789ABCDEF").inverted
-        var strippedSpacesHexadecimal =  pastedInput.components(separatedBy: .whitespacesAndNewlines).joined()
+        var strippedSpacesHexadecimal = pastedInput.components(separatedBy: .whitespacesAndNewlines).joined()
         let isValidHexadecimal = strippedSpacesHexadecimal.uppercased().rangeOfCharacter(from: chars) == nil
-        // Strip leading zeros
         if (strippedSpacesHexadecimal.hasPrefix("0")) {
             strippedSpacesHexadecimal = strippedSpacesHexadecimal.replacingOccurrences(of: "^0+", with: "", options: .regularExpression)
         }
@@ -337,684 +710,9 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
             if (isValidHexadecimal) {
                 alertMessage = "The hexadecimal string in your clipboard must have a length of 16 characters or less."
             }
-            // Alert the user why the paste failed
             let alert = UIAlertController(title: "Paste Failed", message: alertMessage, preferredStyle: .alert)
-
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-            
             self.present(alert, animated: true)
         }
     }
-    
-    // Function to handle a swipe
-    @objc func handleLabelSwipes(_ sender:UISwipeGestureRecognizer) {
-        
-        //Make sure the label was swiped
-        guard (sender.view as? UILabel) != nil else { return }
-        
-        if (sender.direction == .left || sender.direction == .right) {
-            deletePressed(DELBtn)
-            telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.DeleteSwipe)
-        }
-    }
-    
-    //Function for setting up output label gesture recognizers
-    func setupOutputLabelGestureRecognizers() {
-        let labelSingleTap = UITapGestureRecognizer(target: self, action: #selector(self.labelSingleTapped(_:)))
-        labelSingleTap.numberOfTapsRequired = 1
-        let labelDoubleTap = UITapGestureRecognizer(target: self, action: #selector(self.labelDoubleTapped(_:)))
-        labelDoubleTap.numberOfTapsRequired = 2
-        let leftSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
-        let rightSwipe = UISwipeGestureRecognizer(target: self, action: #selector(handleLabelSwipes(_:)))
-            
-        leftSwipe.direction = .left
-        rightSwipe.direction = .right
-
-        self.outputLabel.addGestureRecognizer(leftSwipe)
-        self.outputLabel.addGestureRecognizer(rightSwipe)
-        self.outputLabel.isUserInteractionEnabled = true
-        self.outputLabel.addGestureRecognizer(labelSingleTap)
-        self.outputLabel.addGestureRecognizer(labelDoubleTap)
-        
-        currentlyRecognizingDoubleTap = false
-        
-        // Small optimization to only delay single tap if absolutely necessary
-        if (stateController?.convValues.copyActionIndex == 1 || stateController?.convValues.pasteActionIndex == 1) {
-            labelSingleTap.require(toFail: labelDoubleTap)
-            currentlyRecognizingDoubleTap = true
-        }
-    }
-    
-    //MARK: Button Actions
-    @IBAction func ACPressed(_ sender: RoundButton) {
-        runningNumber = ""
-        leftValue = ""
-        leftValueHex = ""
-        rightValue = ""
-        result = ""
-        currentOperation = .NULL
-        updateOutputLabel(value: "0")
-        
-        stateController?.convValues.largerThan64Bits = false
-        stateController?.convValues.decimalVal = "0"
-        stateController?.convValues.hexVal = "0"
-        stateController?.convValues.binVal = "0"
-    }
-    
-    @IBAction func deletePressed(_ sender: RoundButton) {
-        //Button not available during error state
-        if (stateController?.convValues.largerThan64Bits == true){
-            return
-        }
-        
-        if (runningNumber != "0"){
-            if (runningNumber != ""){
-                runningNumber.removeLast()
-                // Need to be careful if runningNumber becomes empty
-                if (runningNumber == "") {
-                    stateController?.convValues.largerThan64Bits = false
-                    stateController?.convValues.decimalVal = "0"
-                    stateController?.convValues.hexVal = "0"
-                    stateController?.convValues.binVal = "0"
-                    updateOutputLabel(value: "0")
-                }
-                else {
-                    updateOutputLabel(value: runningNumber)
-                    quickUpdateStateController()
-                }
-            }
-        }
-    }
-    
-    @IBAction func secondFunctionPressed(_ sender: RoundButton) {
-        let operatorButtons = [DIVBtn, MULTBtn, SUBBtn, PLUSBtn]
-        
-        if (self.secondFunctionMode) {
-            // Change back to default operators
-            self.changeOperators(buttons: operatorButtons, secondFunctionActive: false)
-            SecondFunctionBtn.backgroundColor = .lightGray
-        }
-        else {
-            // Change to second function operators
-            self.changeOperators(buttons: operatorButtons, secondFunctionActive: true)
-            SecondFunctionBtn.backgroundColor = .white
-        }
-        
-        self.secondFunctionMode.toggle()
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Second)
-    }
-    
-    @IBAction func digitPressed(_ sender: RoundButton) {
-        
-        if (stateController?.convValues.largerThan64Bits == true){
-            runningNumber = ""
-        }
-        
-        //Need to keep the hex value under 64 bits
-        if (runningNumber.count <= 15) {
-            let digit = "\(sender.tag)"
-            if ((digit == "0") && (outputLabel.text == "0")) {
-                //if 0 is pressed and calculator is showing 0 then do nothing
-            }
-            else {
-                let convertedDigit = tagToHex(digitToConvert: digit)
-                // Overwrite running number if it is already 0
-                if (runningNumber == "0") {
-                    runningNumber = convertedDigit
-                }
-                else {
-                    runningNumber += convertedDigit
-                }
-                updateOutputLabel(value: runningNumber)
-                quickUpdateStateController()
-            }
-        }
-    }
-    
-    @IBAction func XORPressed(_ sender: RoundButton) {
-        operation(operation: .XOR)
-    }
-    
-    @IBAction func ORPressed(_ sender: RoundButton) {
-        operation(operation: .OR)
-    }
-    
-    @IBAction func ANDPressed(_ sender: RoundButton) {
-        operation(operation: .AND)
-    }
-    
-    @IBAction func NOTPressed(_ sender: RoundButton) {
-        
-        // Button not available during error state
-        if (stateController?.convValues.largerThan64Bits == true){
-            return
-        }
-        
-        var currentValue = runningNumber
-        if (runningNumber == ""){
-            currentValue = outputLabel.text ?? "0"
-        }
-        
-        let castInt = UInt64(currentValue, radix: 16)!
-        let onesComplimentInt = ~castInt
-        
-        runningNumber = String(onesComplimentInt, radix: 16).uppercased()
-        
-        updateOutputLabel(value: runningNumber)
-        
-        // Add to calculation history
-        let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
-        let calculationData = CalculationData(leftValue: currentValue, rightValue: "", operation: .Not, result: unaryCalculationResult, isUnaryOperation: true)
-        calculationHistory.insert(calculationData, at: 0)
-        
-        quickUpdateStateController()
-    }
-    
-    @IBAction func dividePressed(_ sender: RoundButton) {
-        if secondFunctionMode {
-            // 2's compliment pressed
-            // Button not available during error state or when the value is 0
-            if (stateController?.convValues.largerThan64Bits == true || runningNumber == ""){
-                return
-            }
-            
-            let castInt = UInt64(runningNumber, radix: 16)!
-            let twosComplimentInt = ~castInt + 1
-            
-            runningNumber = String(twosComplimentInt, radix: 16).uppercased()
-            
-            updateOutputLabel(value: runningNumber)
-            
-            quickUpdateStateController()
-        }
-        else {
-            operation(operation: .Divide)
-        }
-    }
-    
-    @IBAction func multiplyPressed(_ sender: RoundButton) {
-        if secondFunctionMode {
-            operation(operation: .Modulus)
-        }
-        else {
-            operation(operation: .Multiply)
-        }
-    }
-    
-    @IBAction func minusPressed(_ sender: RoundButton) {
-        if secondFunctionMode {
-            // Left shift pressed
-            operation(operation: .LeftShift)
-        }
-        else {
-            operation(operation: .Subtract)
-        }
-    }
-    
-    @IBAction func plusPressed(_ sender: RoundButton) {
-        if secondFunctionMode {
-            // Right shift pressed
-            operation(operation: .RightShift)
-        }
-        else {
-            operation(operation: .Add)
-        }
-    }
-    
-    @IBAction func equalsPressed(_ sender: RoundButton) {
-        operation(operation: currentOperation)
-        
-        telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
-        
-        // Completing calculation is a review worthy action
-        ReviewManager.incrementReviewWorthyCount()
-    }
-    
-    //MARK: Private Functions
-    
-    private func operation(operation: Operation) {
-        
-        if currentOperation != .NULL {
-            
-            if runningNumber != "" {
-                leftHexValue = runningNumber
-            }
-            
-            let binRightValue = hexToBin(hexToConvert: runningNumber)
-            if binRightValue != "" {
-                if (binRightValue.first == "1" && binRightValue.count == 64) {
-                    rightValue = String(Int64(bitPattern: UInt64(binRightValue, radix: 2)!))
-                }
-                else {
-                    rightValue = String(Int(binRightValue, radix: 2)!)
-                }
-                runningNumber = ""
-                
-                
-                
-                switch (currentOperation) {
-                    
-                case .Add:
-                    
-                    //Check for an oveflow
-                    let overCheck = Int64(leftValue)!.addingReportingOverflow(Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! + Int(rightValue)!)"
-                    }
-                    
-                case .Subtract:
-
-                    //Check for an overflow
-                    let overCheck = Int64(leftValue)!.subtractingReportingOverflow(Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! - Int(rightValue)!)"
-                    }
-                    
-                case .Multiply:
-                    
-                    //Check for an overflow
-                    let overCheck = Int64(leftValue)!.multipliedReportingOverflow(by: Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! * Int(rightValue)!)"
-                    }
-                    
-                case .Modulus:
-                    //Output Error! if division by 0
-                    if Int(rightValue)! == 0 {
-                        result = "Error!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        return
-                    }
-                    result = "\(Int(Double(leftValue)!.truncatingRemainder(dividingBy: Double(rightValue)!)))"
-                    
-                case .Divide:
-                    //Output Error! if division by 0
-                    if Int(rightValue)! == 0 {
-                        result = "Error!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        return
-                    }
-                    let overCheck = Int64(leftValue)!.dividedReportingOverflow(by: Int64(rightValue)!)
-                    if (overCheck.overflow) {
-                        result = "Error! Integer Overflow!"
-                        updateOutputLabel(value: result)
-                        currentOperation = operation
-                        stateController?.convValues.largerThan64Bits = true
-                        stateController?.convValues.decimalVal = "0"
-                        return
-                    }
-                    else {
-                        result = "\(Int(leftValue)! / Int(rightValue)!)"
-                    }
-                
-                case .LeftShift:
-                    result = "\(Int(leftValue)! << Int(rightValue)!)"
-                    
-                case .RightShift:
-                    let currValue = hexToBin(hexToConvert: leftValueHex)
-                    let rightShiftRight = Int(rightValue)!
-                    if (rightShiftRight <= 0) {
-                        result = leftValue
-                    }
-                    else if (rightShiftRight > currValue.count) {
-                        result = "0"
-                    }
-                    else {
-                        result = String(Int(UInt64(currValue.dropLast(rightShiftRight), radix: 2)!))
-                    }
-                    
-                case .AND:
-                    result = "\(Int(leftValue)! & Int(rightValue)!)"
-                    
-                case .OR:
-                    result = "\(Int(leftValue)! | Int(rightValue)!)"
-                    
-                case .XOR:
-                    result = "\(Int(leftValue)! ^ Int(rightValue)!)"
-                    
-                //Should not occur
-                default:
-                    fatalError("Unexpected Operation...")
-                }
-                
-                leftValue = result
-                setupStateControllerValues()
-                
-                let hexRepresentation = stateController?.convValues.hexVal ?? "0"
-                var newLabelValue = hexRepresentation.uppercased()
-                leftValueHex = newLabelValue
-                if ((hexRepresentation.contains("-"))){
-                    newLabelValue = formatNegativeHex(hexToConvert: newLabelValue).uppercased()
-                }
-                updateOutputLabel(value: newLabelValue)
-                
-                let calculationData = CalculationData(leftValue: rightHexValue, rightValue: leftHexValue, operation: currentOperation, result: newLabelValue, isUnaryOperation: false)
-                calculationHistory.insert(calculationData, at: 0)
-                
-                rightHexValue = newLabelValue
-            }
-            currentOperation = operation
-        }
-        else {
-            rightHexValue = runningNumber
-            //If string is empty it should be interpreted as a 0
-            let binLeftValue = hexToBin(hexToConvert: runningNumber)
-            if (runningNumber == "") {
-                if (leftValue == "") {
-                    leftValue = "0"
-                    leftValueHex = "0"
-                }
-            }
-            else {
-                leftValueHex = runningNumber
-                if (binLeftValue.first == "1" && binLeftValue.count == 64){
-                    leftValue = String(Int64(bitPattern: UInt64(binLeftValue, radix: 2)!))
-                }
-                else {
-                    leftValue = String(Int(binLeftValue, radix: 2)!)
-                }
-            }
-            runningNumber = ""
-            
-            currentOperation = operation
-        }
-    }
-    
-    private func setupStateControllerValues() {
-        stateController?.convValues.decimalVal = result
-        let hexConversion = String(Int(result)!, radix: 16)
-        let binConversion = String(Int(result)!, radix: 2)
-        stateController?.convValues.hexVal = hexConversion
-        stateController?.convValues.binVal = binConversion
-    }
-    
-    //Perform a quick update to keep the state controller variables in sync with the calculator label
-    private func quickUpdateStateController() {
-        
-        if (runningNumber.count < 17){
-            stateController?.convValues.largerThan64Bits = false
-        }
-        
-        //Need to keep the state controller updated with what is on the screen
-        stateController?.convValues.hexVal = runningNumber
-        //Need to convert differently if binary is positive or negative
-        var binCurrentVal = ""
-        var decCurrentVal = ""
-        //We are dealing with a negative number
-        if ((!outputLabel.text!.first!.isNumber || ((outputLabel.text!.first == "9") || (outputLabel.text!.first == "8"))) && (outputLabel.text!.count == 16)){
-            //Need to perform special operation here
-            var currentLabel = runningNumber
-            currentLabel = hexToBin(hexToConvert: currentLabel)
-            binCurrentVal = currentLabel
-            decCurrentVal = String(Int64(bitPattern: UInt64(currentLabel, radix: 2)!))
-        }
-        else {
-            binCurrentVal = String(Int(runningNumber, radix: 16)!, radix: 2)
-            decCurrentVal = String(Int(runningNumber, radix: 16)!)
-        }
-        stateController?.convValues.binVal = binCurrentVal
-        stateController?.convValues.decimalVal = decCurrentVal
-    }
-    
-    //Helper function to convert the button tags to hex digits
-    private func tagToHex(digitToConvert: String) -> String {
-        var result = ""
-        if (Int(digitToConvert)! < 10){
-            result = digitToConvert
-        }
-        else {
-            if (Int(digitToConvert)! == 10) {
-                result = "A"
-            }
-            else if (Int(digitToConvert)! == 11) {
-                result = "B"
-            }
-            else if (Int(digitToConvert)! == 12) {
-                result = "C"
-            }
-            else if (Int(digitToConvert)! == 13) {
-                result = "D"
-            }
-            else if (Int(digitToConvert)! == 14) {
-                result = "E"
-            }
-            else if (Int(digitToConvert)! == 15) {
-                result = "F"
-            }
-            else {
-                //Should not occur ...
-            }
-        }
-        return result
-    }
-    
-    //Helper function to convert hex to binary
-    private func hexToBin(hexToConvert: String) -> String {
-        var result = ""
-        var copy = hexToConvert.uppercased()
-        
-        if (hexToConvert == ""){
-            return hexToConvert
-        }
-        
-        for _ in 0..<hexToConvert.count {
-            let currentDigit = copy.first
-            copy.removeFirst()
-            
-            switch currentDigit {
-            case "0":
-                result += "0000"
-            case "1":
-                result += "0001"
-            case "2":
-                result += "0010"
-            case "3":
-                result += "0011"
-            case "4":
-                result += "0100"
-            case "5":
-                result += "0101"
-            case "6":
-                result += "0110"
-            case "7":
-                result += "0111"
-            case "8":
-                result += "1000"
-            case "9":
-                result += "1001"
-            case "A":
-                result += "1010"
-            case "B":
-                result += "1011"
-            case "C":
-                result += "1100"
-            case "D":
-                result += "1101"
-            case "E":
-                result += "1110"
-            case "F":
-                result += "1111"
-            default:
-                fatalError("Unexpected Operation...")
-            }
-        }
-        
-        return result
-    }
-    //Helper function to convert negative hexadecimal number to sign extended equivalent
-    private func formatNegativeHex(hexToConvert: String) -> String {
-        var manipulatedString = hexToConvert
-        manipulatedString.removeFirst()
-        
-        //Special hex representation of integer min
-        if (manipulatedString == "8000000000000000"){
-            return manipulatedString
-        }
-        
-        //Need to convert the binary, then flip all the bits, add 1 and convert back to hex
-        let binaryInitial = String(Int(manipulatedString, radix:16)!, radix: 2)
-        var invertedBinary = ""
-        
-        //Flip all bits
-        for i in 0..<binaryInitial.count {
-            if (binaryInitial[binaryInitial.index(binaryInitial.startIndex, offsetBy: i)] == "0"){
-                invertedBinary += "1"
-            }
-            else {
-                invertedBinary += "0"
-            }
-        }
-        
-        //Add 1 to the string
-        let index = invertedBinary.lastIndex(of: "0") ?? (invertedBinary.endIndex)
-        var newSubString = String(invertedBinary.prefix(upTo: index))
-        
-        
-        if (newSubString.count < invertedBinary.count) {
-            newSubString = newSubString + "1"
-        }
-        
-        while (newSubString.count < invertedBinary.count) {
-            newSubString = newSubString + "0"
-        }
-        
-        //Sign extend
-        while (newSubString.count < 64) {
-            newSubString = "1" + newSubString
-        }
-        
-        //Finally, convert to hexadecimal manually
-        var hexResult = ""
-        for _ in 0..<16 {
-            //Take last 4 bits and convert to hex
-            let currentIndex = newSubString.index(newSubString.endIndex, offsetBy: -4)
-            let currentBinary = String(newSubString.suffix(from: currentIndex))
-            newSubString.removeLast(4)
-            
-            switch currentBinary {
-            case "0000":
-                hexResult = "0" + hexResult
-            case "0001":
-                hexResult = "1" + hexResult
-            case "0010":
-                hexResult = "2" + hexResult
-            case "0011":
-                hexResult = "3" + hexResult
-            case "0100":
-                hexResult = "4" + hexResult
-            case "0101":
-                hexResult = "5" + hexResult
-            case "0110":
-                hexResult = "6" + hexResult
-            case "0111":
-                hexResult = "7" + hexResult
-            case "1000":
-                hexResult = "8" + hexResult
-            case "1001":
-                hexResult = "9" + hexResult
-            case "1010":
-                hexResult = "a" + hexResult
-            case "1011":
-                hexResult = "b" + hexResult
-            case "1100":
-                hexResult = "c" + hexResult
-            case "1101":
-                hexResult = "d" + hexResult
-            case "1110":
-                hexResult = "e" + hexResult
-            case "1111":
-                hexResult = "f" + hexResult
-            default:
-                fatalError("Unexpected Operation...")
-            }
-        }
-        
-        return hexResult
-    }
-    
-    //Function to check whether the user wants the output text label colour to be the same as the overall theme
-    private func setupCalculatorTextColour(state: Bool, colourToSet: UIColor){
-        if (state) {
-            outputLabel.textColor = colourToSet
-        }
-        else {
-            outputLabel.textColor = UIColor.white
-        }
-    }
-    
-    // Used to change the display text of buttons for second function mode
-    private func changeOperators(buttons: [RoundButton?], secondFunctionActive: Bool) {
-        if secondFunctionActive {
-            for (i, button) in buttons.enumerated() {
-                switch i {
-                case 0:
-                    button?.setTitle("2's", for: .normal)
-                case 1:
-                    button?.setTitle("MOD", for: .normal)
-                case 2:
-                    button?.setTitle("<<X", for: .normal)
-                case 3:
-                    button?.setTitle(">>X", for: .normal)
-                default:
-                    fatalError("Index out of range")
-                }
-            }
-        }
-        else {
-            for (i, button) in buttons.enumerated() {
-                switch i {
-                case 0:
-                    button?.setTitle("÷", for: .normal)
-                case 1:
-                    button?.setTitle("×", for: .normal)
-                case 2:
-                    button?.setTitle("-", for: .normal)
-                case 3:
-                    button?.setTitle("+", for: .normal)
-                default:
-                    fatalError("Index out of range")
-                }
-            }
-        }
-    }
-    
-    // Standardized function to update the output label
-    private func updateOutputLabel(value: String) {
-        outputLabel.text = value
-        outputLabel.accessibilityLabel = value
-    }
-}
-
-//Adds state controller to the view controller
-extension HexadecimalViewController: StateControllerProtocol {
-  func setState(state: StateController) {
-    self.stateController = state
-  }
 }

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -77,6 +77,9 @@ class HexadecimalViewController: CalculatorViewController {
         return runningNumber
     }
 
+    override var outputLabelAccessibilityIdentifier: String { "Hexadecimal Output Label" }
+    override var defaultLabelValue: String { "0" }
+
     override func updateThemeColour(_ colour: UIColor) {
         PLUSBtn.backgroundColor = colour
         SUBBtn.backgroundColor = colour
@@ -85,29 +88,14 @@ class HexadecimalViewController: CalculatorViewController {
         EQUALSBtn.backgroundColor = colour
         outputLabel.textColor = colour
     }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        outputLabel.accessibilityIdentifier = "Hexadecimal Output Label"
-        updateOutputLabel(value: "0")
-
-        // convValues is pre-populated by HexaCalcTabBarController.viewDidLoad before any child VC loads
-        if let colour = stateController?.convValues.colour {
-            updateThemeColour(colour)
-        }
-        setupCalculatorTextColour(
-            state: stateController?.convValues.setCalculatorTextColour ?? false,
-            colourToSet: stateController?.convValues.colour ?? .systemGreen
-        )
-
-        setupOutputLabelGestureRecognizers()
-        overrideUserInterfaceStyle = .light
-
+        outputLabel.accessibilityIdentifier = outputLabelAccessibilityIdentifier
+        setupCommonViewDidLoad()
         if #available(iOS 17.0, *) {
             traitOverrides.horizontalSizeClass = .compact
         }
-
-        ReviewManager.requestReviewIfAppropriate()
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Introduces a `CalculatorViewController.swift` from which the rest of the calculator view controllers inherit from.