### PR TITLE
Fix tab buttons not disappearing on iOS 26

### DIFF
--- a/HexaCalc/SceneDelegate.swift
+++ b/HexaCalc/SceneDelegate.swift
@@ -37,6 +37,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
 
+        // Inject state into the tab bar controller itself so it can initialize
+        // convValues and apply tab states before any child VC loads
+        if let hexaTabBar = tabBarController as? HexaCalcTabBarController {
+            hexaTabBar.setState(state: stateController)
+        }
+
         // Set the rootViewController to our modified version with the StateController instances
         self.window!.rootViewController = tabBarController
         self.window!.makeKeyAndVisible()

--- a/HexaCalc/View Controllers/HexaCalcTabBarController.swift
+++ b/HexaCalc/View Controllers/HexaCalcTabBarController.swift
@@ -8,7 +8,16 @@
 
 import UIKit
 
-class HexaCalcTabBarController: UITabBarController {
+class HexaCalcTabBarController: UITabBarController, StateControllerProtocol {
+
+    // All VCs in storyboard order: Hex=0, Binary=1, Decimal=2, Settings=3
+    private var allViewControllers: [UIViewController] = []
+    private var enabledStates: [Bool] = [true, true, true, true]
+    var stateController: StateController?
+
+    func setState(state: StateController) {
+        stateController = state
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,5 +25,55 @@ class HexaCalcTabBarController: UITabBarController {
         if #available(iOS 17.0, *) {
             traitOverrides.horizontalSizeClass = .compact
         }
+
+        // Capture the full VC list before any tabs are removed
+        allViewControllers = viewControllers ?? []
+
+        guard let savedPreferences = DataPersistence.loadPreferences() else { return }
+
+        // Populate shared state so all child VCs have it when their viewDidLoad runs
+        stateController?.convValues.setCalculatorTextColour = savedPreferences.setCalculatorTextColour
+        stateController?.convValues.colour = savedPreferences.colour
+        stateController?.convValues.copyActionIndex = savedPreferences.copyActionIndex
+        stateController?.convValues.pasteActionIndex = savedPreferences.pasteActionIndex
+        stateController?.convValues.historyButtonViewIndex = savedPreferences.historyButtonViewIndex
+        stateController?.convValues.defaultTabIndex = savedPreferences.defaultTabIndex
+
+        // Remove disabled tabs before any child VC loads (avoids mutating viewControllers
+        // from within a child VC's own viewDidLoad, which crashes on iOS 26+)
+        if !savedPreferences.hexTabState { setTab(0, enabled: false) }
+        if !savedPreferences.binTabState { setTab(1, enabled: false) }
+        if !savedPreferences.decTabState { setTab(2, enabled: false) }
+
+        // Honor the user's default tab preference
+        let defaultIndex = Int(savedPreferences.defaultTabIndex)
+        if defaultIndex < allViewControllers.count, defaultIndex != 3 {
+            let targetVC = allViewControllers[defaultIndex]
+            if let newIndex = viewControllers?.firstIndex(of: targetVC) {
+                selectedIndex = newIndex
+            }
+        }
+    }
+
+    // Enable or disable a tab by its original storyboard index.
+    func setTab(_ index: Int, enabled: Bool) {
+        guard index < enabledStates.count else { return }
+
+        // At runtime: if the currently active tab is being disabled, switch away first
+        if !enabled,
+           let current = selectedViewController,
+           index < allViewControllers.count,
+           current == allViewControllers[index] {
+            let nextVC = allViewControllers.enumerated()
+                .first { $0.offset != index && enabledStates[$0.offset] }?.element
+            if let nextVC = nextVC {
+                selectedViewController = nextVC
+            }
+        }
+
+        enabledStates[index] = enabled
+        viewControllers = allViewControllers.enumerated()
+            .filter { enabledStates[$0.offset] }
+            .map { $0.element }
     }
 }

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -77,11 +77,6 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
 
     var calculationHistory: [CalculationData] = []
     
-    // Decide which tab to be default in viewDidLoad, but set the selected tab after the view appears
-    // Only do this on the first launch
-    var initialTabIndex = 0
-    var initialLaunch = true
-    
     // Access singleton TelemetryManager class object
     let telemetryManager = TelemetryManager.sharedTelemetryManager
     let telemetryTab = TelemetryTab.Hexadecimal
@@ -92,65 +87,18 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
         outputLabel.accessibilityIdentifier = "Hexadecimal Output Label"
         updateOutputLabel(value: "0")
         
-        if let savedPreferences = DataPersistence.loadPreferences() {
-            
-            // Initialize initial tab to user saved preference
-            initialTabIndex = Int(savedPreferences.defaultTabIndex == 3 ? 0 : savedPreferences.defaultTabIndex)
-
-            // Remove tabs which are disabled by the user
-            let arrayOfTabBarItems = tabBarController?.tabBar.items
-            var removeHexTab = false
-            if let barItems = arrayOfTabBarItems, barItems.count > 0 {
-                if (savedPreferences.hexTabState == false) {
-                    removeHexTab = true
-                    initialTabIndex = initialTabIndex == 0 ? 1 : initialTabIndex
-                }
-                if (savedPreferences.binTabState == false) {
-                    tabBarController?.tabBar.items![1].isEnabled = false
-                    if (initialTabIndex == 1 && savedPreferences.hexTabState) {
-                        initialTabIndex = 0
-                    }
-                    else {
-                        initialTabIndex = initialTabIndex == 1 ? 2 : initialTabIndex
-                    }
-                }
-                if (savedPreferences.decTabState == false) {
-                    tabBarController?.tabBar.items![2].isEnabled = false
-                    if (initialTabIndex == 2 && savedPreferences.hexTabState) {
-                        initialTabIndex = 0
-                    }
-                    else if (initialTabIndex == 2 && savedPreferences.binTabState) {
-                        initialTabIndex = 1
-                    }
-                    else {
-                        initialTabIndex = initialTabIndex == 2 ? 3 : initialTabIndex
-                    }
-                }
-                if (removeHexTab == true) {
-                    //Remove hexadecimal tab after setting state values
-                    stateController?.convValues.setCalculatorTextColour = savedPreferences.setCalculatorTextColour
-                    stateController?.convValues.colour = savedPreferences.colour
-                    stateController?.convValues.copyActionIndex = savedPreferences.copyActionIndex
-                    stateController?.convValues.pasteActionIndex = savedPreferences.pasteActionIndex
-                    tabBarController?.tabBar.items![0].isEnabled = false
-                }
-            }
-            
-            PLUSBtn.backgroundColor = savedPreferences.colour
-            SUBBtn.backgroundColor = savedPreferences.colour
-            MULTBtn.backgroundColor = savedPreferences.colour
-            DIVBtn.backgroundColor = savedPreferences.colour
-            EQUALSBtn.backgroundColor = savedPreferences.colour
-            
-            setupCalculatorTextColour(state: savedPreferences.setCalculatorTextColour, colourToSet: savedPreferences.colour)
-            
-            stateController?.convValues.setCalculatorTextColour = savedPreferences.setCalculatorTextColour
-            stateController?.convValues.colour = savedPreferences.colour
-            stateController?.convValues.copyActionIndex = savedPreferences.copyActionIndex
-            stateController?.convValues.pasteActionIndex = savedPreferences.pasteActionIndex
-            stateController?.convValues.historyButtonViewIndex = savedPreferences.historyButtonViewIndex
-            stateController?.convValues.defaultTabIndex = savedPreferences.defaultTabIndex
+        // convValues is pre-populated by HexaCalcTabBarController.viewDidLoad before any child VC loads
+        if let colour = stateController?.convValues.colour {
+            PLUSBtn.backgroundColor = colour
+            SUBBtn.backgroundColor = colour
+            MULTBtn.backgroundColor = colour
+            DIVBtn.backgroundColor = colour
+            EQUALSBtn.backgroundColor = colour
         }
+        setupCalculatorTextColour(
+            state: stateController?.convValues.setCalculatorTextColour ?? false,
+            colourToSet: stateController?.convValues.colour ?? .systemGreen
+        )
 
         //Setup gesture recognizers
         self.setupOutputLabelGestureRecognizers()
@@ -267,13 +215,6 @@ class HexadecimalViewController: UIViewController, HistoryButtonHost {
         //Set calculator text colour
         setupCalculatorTextColour(state: stateController?.convValues.setCalculatorTextColour ?? false, colourToSet: stateController?.convValues.colour ?? UIColor.systemGreen)
         
-        // Set the initial tab (if it is not the Hexadecimal tab) after the view has loaded
-        if initialTabIndex != 0 && initialLaunch {
-            // Only change the selected tab on the first launch
-            initialLaunch = false
-            // Set the correct selected tab item
-            tabBarController?.selectedViewController = tabBarController?.viewControllers![initialTabIndex]
-        }
     }
     
     // iPad support is for portrait and landscape mode, need to alter constraints on device rotation

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -441,14 +441,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
-        if sender.isOn {
-            DataPersistence.savePreferences(userPreferences: userPreferences)
-            tabBarController?.tabBar.items![0].isEnabled = true
-        }
-        else {
-            DataPersistence.savePreferences(userPreferences: userPreferences)
-            tabBarController?.tabBar.items![0].isEnabled = false
-        }
+        DataPersistence.savePreferences(userPreferences: userPreferences)
+        (tabBarController as? HexaCalcTabBarController)?.setTab(0, enabled: sender.isOn)
         self.preferences = userPreferences
         
         telemetryManager.sendSettingsSignal(
@@ -466,14 +460,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
-        if sender.isOn {
-            DataPersistence.savePreferences(userPreferences: userPreferences)
-            tabBarController?.tabBar.items![1].isEnabled = true
-        }
-        else {
-            DataPersistence.savePreferences(userPreferences: userPreferences)
-            tabBarController?.tabBar.items![1].isEnabled = false
-        }
+        DataPersistence.savePreferences(userPreferences: userPreferences)
+        (tabBarController as? HexaCalcTabBarController)?.setTab(1, enabled: sender.isOn)
         self.preferences = userPreferences
         
         telemetryManager.sendSettingsSignal(
@@ -491,14 +479,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
-        if sender.isOn {
-            DataPersistence.savePreferences(userPreferences: userPreferences)
-            tabBarController?.tabBar.items![2].isEnabled = true
-        }
-        else {
-            DataPersistence.savePreferences(userPreferences: userPreferences)
-            tabBarController?.tabBar.items![2].isEnabled = false
-        }
+        DataPersistence.savePreferences(userPreferences: userPreferences)
+        (tabBarController as? HexaCalcTabBarController)?.setTab(2, enabled: sender.isOn)
         self.preferences = userPreferences
         
         telemetryManager.sendSettingsSignal(

--- a/HexaCalcUITests/SettingsHexaCalcUITests.swift
+++ b/HexaCalcUITests/SettingsHexaCalcUITests.swift
@@ -10,64 +10,119 @@ import XCTest
 import UIKit
 
 class SettingsHexaCalcUITests: XCTestCase {
-    
+
     override func setUpWithError() throws {
         // Navigate to the settings tab before running each test
-        
+
         let app = XCUIApplication()
         app.launch()
-        
+
         let tabBar = app.tabBars["Tab Bar"]
+
+        // Reset any tab switches left disabled by a previous failed run, then load the
+        // Hexadecimal VC so that tab-enable/disable actions work correctly in all tests.
         tabBar.buttons["Settings"].tap()
-        
+        for name in ["Hexadecimal", "Binary", "Decimal"] {
+            let sw = app.switches[name]
+            if sw.exists, (sw.value as? String) == "0" {
+                sw.tap()
+            }
+        }
+        tabBar.buttons["Hexadecimal"].tap()
+        tabBar.buttons["Settings"].tap()
+
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
     }
-    
+
     func testTabDisabling() throws {
         let app = XCUIApplication()
         let tabBar = app.tabBars["Tab Bar"]
-        
-        // Ensure all tabs appear at start
+
+        // Reset any switches left off by a previous failed run
+        for name in ["Hexadecimal", "Binary", "Decimal"] {
+            let sw = app.switches[name]
+            if sw.exists, (sw.value as? String) == "0" { sw.tap() }
+        }
+
+        // All tabs visible at start
         XCTAssert(tabBar.buttons["Hexadecimal"].exists)
         XCTAssert(tabBar.buttons["Binary"].exists)
         XCTAssert(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
-        
+
         app.switches["Hexadecimal"].tap()
         XCTAssertFalse(tabBar.buttons["Hexadecimal"].exists)
         XCTAssert(tabBar.buttons["Binary"].exists)
         XCTAssert(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
-        
+
         app.switches["Binary"].tap()
         XCTAssertFalse(tabBar.buttons["Hexadecimal"].exists)
         XCTAssertFalse(tabBar.buttons["Binary"].exists)
         XCTAssert(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
-        
+
         app.switches["Decimal"].tap()
         XCTAssertFalse(tabBar.buttons["Hexadecimal"].exists)
         XCTAssertFalse(tabBar.buttons["Binary"].exists)
         XCTAssertFalse(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
-        
+
         app.switches["Hexadecimal"].tap()
         XCTAssert(tabBar.buttons["Hexadecimal"].exists)
         XCTAssertFalse(tabBar.buttons["Binary"].exists)
         XCTAssertFalse(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
-        
+
         app.switches["Decimal"].tap()
         XCTAssert(tabBar.buttons["Hexadecimal"].exists)
         XCTAssertFalse(tabBar.buttons["Binary"].exists)
         XCTAssert(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
-        
+
         app.switches["Binary"].tap()
         XCTAssert(tabBar.buttons["Hexadecimal"].exists)
         XCTAssert(tabBar.buttons["Binary"].exists)
         XCTAssert(tabBar.buttons["Decimal"].exists)
         XCTAssert(tabBar.buttons["Settings"].exists)
+    }
+
+    func testThemeColourChange() throws {
+        let app = XCUIApplication()
+
+        // Navigate to Colour selection — tapping a row auto-pops back to Settings
+        app.tables.staticTexts["Colour"].tap()
+
+        // The selection list shows ["Red", "Orange", "Yellow", "Green", "Blue", "Teal", "Indigo", "Violet", "Pink", "Brown"]
+        // Select "Red" — this saves the selection and automatically navigates back
+        app.tables.staticTexts["Red"].tap()
+
+        // Back on Settings — colour cell summary should now show "Red"
+        XCTAssert(app.staticTexts["Red"].waitForExistence(timeout: 2))
+
+        // Restore to Green (default) — same auto-pop pattern
+        app.tables.staticTexts["Colour"].tap()
+        app.tables.staticTexts["Green"].tap()
+
+        XCTAssert(app.staticTexts["Green"].waitForExistence(timeout: 2))
+    }
+
+    func testDefaultTabSetting() throws {
+        let app = XCUIApplication()
+
+        // Navigate to Default Selected Tab selection — tapping a row auto-pops back
+        app.tables.staticTexts["Override Default Selected Tab"].tap()
+
+        // The selection list shows ["Hexadecimal", "Binary", "Decimal", "Off"]
+        // Select "Decimal" and auto-pop back to Settings
+        app.tables.staticTexts["Decimal"].tap()
+
+        // Navigate back into the selection to restore to Off
+        app.tables.staticTexts["Override Default Selected Tab"].tap()
+        app.tables.staticTexts["Off"].tap()
+
+        // "Off" is unique to the summary — not a tab switch label
+        XCTAssert(app.staticTexts["Off"].waitForExistence(timeout: 2))
     }
 }


### PR DESCRIPTION
## Summary

- `UITabBarItem.isEnabled = false` no longer visually removes tab buttons in iOS 26
  (it only grays them out). Replace with actual add/remove of VCs from
  `tabBarController.viewControllers`.
- Move all preferences loading and tab state initialization to
  `HexaCalcTabBarController.viewDidLoad` so it runs before any child VC loads,
  fixing a crash on relaunch when the Hexadecimal tab was disabled.
- `SettingsViewController` switch handlers now call `setTab(_:enabled:)` for
  live runtime toggle behavior.

## Test plan

- [x] Toggle each tab switch in Settings — button should immediately appear/disappear
- [x] Disable Hexadecimal tab, force-quit, relaunch — opens on Binary/Decimal without crashing
- [x] Re-enable a disabled tab — button reappears immediately
- [x] Disable all three calculator tabs — only Settings remains
- [x] Set a default tab, force-quit, relaunch — opens on the correct tab
- [x] Colour theme and other settings still apply correctly on launch