### PR TITLE
Add history enable/disable setting and simplify button view options

### DIFF
--- a/HexaCalc/AppDelegate.swift
+++ b/HexaCalc/AppDelegate.swift
@@ -53,7 +53,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             copyActionIndex: loadedPreferences.copyActionIndex,
                             pasteActionIndex: loadedPreferences.pasteActionIndex,
                             historyButtonViewIndex: 0,
-                            defaultTabIndex: 3
+                            defaultTabIndex: 3,
+                            historyEnabled: loadedPreferences.historyEnabled
                         )
                         DataPersistence.savePreferences(userPreferences: userPreferences)
                         UserDefaults.standard.set(appVersionNumber, forKey: "CurrentVersionNumber")
@@ -78,7 +79,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             copyActionIndex: loadedPreferences.copyActionIndex,
                             pasteActionIndex: loadedPreferences.pasteActionIndex,
                             historyButtonViewIndex: 0,
-                            defaultTabIndex: 3
+                            defaultTabIndex: 3,
+                            historyEnabled: loadedPreferences.historyEnabled
                         )
                         DataPersistence.savePreferences(userPreferences: userPreferences)
                         UITabBar.appearance().tintColor = UIColor.systemGreen

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -45,31 +45,12 @@ extension HistoryButtonHost where Self: UIViewController {
         historyButtonHorizontalConstraint = horizontalConstraint
 
         NSLayoutConstraint.activate([
-            historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60),
+            historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
             historyButton.heightAnchor.constraint(equalToConstant: 44)
         ])
 
         historyButton.accessibilityIdentifier = "History Button"
         historyButton.addTarget(self, action: #selector(historyButtonTapped), for: .touchUpInside)
-    }
-
-    // Moves the button to the leading edge on iPad landscape to avoid overlapping the output label.
-    func repositionHistoryButton(for targetSize: CGSize? = nil) {
-        guard historyButton?.superview != nil else { return }
-
-        let size = targetSize ?? view.bounds.size
-        let isIPadLandscape = UIDevice.current.userInterfaceIdiom == .pad && size.width > size.height
-
-        historyButtonHorizontalConstraint?.isActive = false
-
-        let newConstraint: NSLayoutConstraint
-        if isIPadLandscape {
-            newConstraint = historyButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16)
-        } else {
-            newConstraint = historyButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
-        }
-        newConstraint.isActive = true
-        historyButtonHorizontalConstraint = newConstraint
     }
 
     func updateHistoryButton(stateController: StateController?) {
@@ -80,8 +61,6 @@ extension HistoryButtonHost where Self: UIViewController {
             historyButton.alpha = 1
             return
         }
-
-        repositionHistoryButton()
 
         let colour = stateController?.convValues.colour ?? .systemGreen
         let viewIndex = stateController?.convValues.historyButtonViewIndex ?? 0

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -11,6 +11,7 @@ import UIKit
 @objc protocol HistoryButtonHost: AnyObject {
     var historyButton: UIButton! { get set }
     var historyButtonWidthConstraint: NSLayoutConstraint? { get set }
+    var historyButtonHorizontalConstraint: NSLayoutConstraint? { get set }
     func historyButtonTapped()
 }
 
@@ -27,26 +28,48 @@ extension HistoryButtonHost where Self: UIViewController {
         if historyButton?.superview != nil {
             return
         }
-        
+
         historyButton = UIButton(type: .system)
         historyButton.translatesAutoresizingMaskIntoConstraints = false
         historyButton.layer.cornerRadius = 22
         historyButton.clipsToBounds = true
-        
+
         view.addSubview(historyButton)
 
         let widthConstraint = historyButton.widthAnchor.constraint(equalToConstant: 44)
         widthConstraint.isActive = true
         historyButtonWidthConstraint = widthConstraint
 
+        let horizontalConstraint = historyButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+        horizontalConstraint.isActive = true
+        historyButtonHorizontalConstraint = horizontalConstraint
+
         NSLayoutConstraint.activate([
             historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60),
-            historyButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
             historyButton.heightAnchor.constraint(equalToConstant: 44)
         ])
 
         historyButton.accessibilityIdentifier = "History Button"
         historyButton.addTarget(self, action: #selector(historyButtonTapped), for: .touchUpInside)
+    }
+
+    // Moves the button to the leading edge on iPad landscape to avoid overlapping the output label.
+    func repositionHistoryButton(for targetSize: CGSize? = nil) {
+        guard historyButton?.superview != nil else { return }
+
+        let size = targetSize ?? view.bounds.size
+        let isIPadLandscape = UIDevice.current.userInterfaceIdiom == .pad && size.width > size.height
+
+        historyButtonHorizontalConstraint?.isActive = false
+
+        let newConstraint: NSLayoutConstraint
+        if isIPadLandscape {
+            newConstraint = historyButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16)
+        } else {
+            newConstraint = historyButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+        }
+        newConstraint.isActive = true
+        historyButtonHorizontalConstraint = newConstraint
     }
 
     func updateHistoryButton(stateController: StateController?) {
@@ -57,6 +80,8 @@ extension HistoryButtonHost where Self: UIViewController {
             historyButton.alpha = 1
             return
         }
+
+        repositionHistoryButton()
 
         let colour = stateController?.convValues.colour ?? .systemGreen
         let viewIndex = stateController?.convValues.historyButtonViewIndex ?? 0

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -12,6 +12,7 @@ import UIKit
     var historyButton: UIButton! { get set }
     var historyButtonWidthConstraint: NSLayoutConstraint? { get set }
     var historyButtonHorizontalConstraint: NSLayoutConstraint? { get set }
+    var historyButtonTopConstraint: NSLayoutConstraint? { get set }
     func historyButtonTapped()
 }
 
@@ -44,13 +45,31 @@ extension HistoryButtonHost where Self: UIViewController {
         horizontalConstraint.isActive = true
         historyButtonHorizontalConstraint = horizontalConstraint
 
-        NSLayoutConstraint.activate([
-            historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
-            historyButton.heightAnchor.constraint(equalToConstant: 44)
-        ])
+        let topConstraint = historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60)
+        topConstraint.isActive = true
+        historyButtonTopConstraint = topConstraint
+
+        historyButton.heightAnchor.constraint(equalToConstant: 44).isActive = true
 
         historyButton.accessibilityIdentifier = "History Button"
         historyButton.addTarget(self, action: #selector(historyButtonTapped), for: .touchUpInside)
+    }
+
+    func repositionHistoryButton(for targetSize: CGSize? = nil) {
+        guard historyButton?.superview != nil else { return }
+
+        let size = targetSize ?? view.bounds.size
+        let isLandscape = size.width > size.height
+
+        historyButtonTopConstraint?.isActive = false
+        let topConstraint: NSLayoutConstraint
+        if isLandscape {
+            topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
+        } else {
+            topConstraint = historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60)
+        }
+        topConstraint.isActive = true
+        historyButtonTopConstraint = topConstraint
     }
 
     func updateHistoryButton(stateController: StateController?) {
@@ -61,6 +80,8 @@ extension HistoryButtonHost where Self: UIViewController {
             historyButton.alpha = 1
             return
         }
+
+        repositionHistoryButton()
 
         let colour = stateController?.convValues.colour ?? .systemGreen
         let viewIndex = stateController?.convValues.historyButtonViewIndex ?? 0

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -50,9 +50,17 @@ extension HistoryButtonHost where Self: UIViewController {
     }
 
     func updateHistoryButton(stateController: StateController?) {
+        let historyEnabled = stateController?.convValues.historyEnabled ?? true
+
+        guard historyEnabled else {
+            historyButton.isHidden = true
+            historyButton.alpha = 1
+            return
+        }
+
         let colour = stateController?.convValues.colour ?? .systemGreen
         let viewIndex = stateController?.convValues.historyButtonViewIndex ?? 0
-        
+
         // Start invisible for fade-in animation
         historyButton.alpha = 0
 
@@ -103,16 +111,10 @@ extension HistoryButtonHost where Self: UIViewController {
             historyButtonWidthConstraint = historyButton.widthAnchor.constraint(equalToConstant: newWidth > 0 ? newWidth : 220)
             historyButtonWidthConstraint?.isActive = true
 
-        case 2:
-            historyButton.isHidden = true
-            // No animation needed when hidden
-            historyButton.alpha = 1
-            return
-
         default:
             fatalError("Unexpected historyButtonViewIndex")
         }
-        
+
         // Fade in to match tab bar transition timing
         UIView.animate(withDuration: 0.2, delay: 0.1, options: .curveEaseIn) {
             self.historyButton.alpha = 1

--- a/HexaCalc/Model/HistoryButtonViewConverter.swift
+++ b/HexaCalc/Model/HistoryButtonViewConverter.swift
@@ -16,8 +16,6 @@ class HistoryButtonViewConverter {
             return "Icon Image"
         case 1:
             return "Text Label"
-        case 2:
-            return "Off"
         default:
             return "Icon Image"
         }

--- a/HexaCalc/Model/StateController.swift
+++ b/HexaCalc/Model/StateController.swift
@@ -21,6 +21,7 @@ struct convVals{
     var copyActionIndex: Int32 = 0
     var pasteActionIndex: Int32 = 1
     var historyButtonViewIndex: Int32 = 0
+    var historyEnabled: Bool = true
     // Acts as a binary flag (1 bit for each calculator)
     var clearLocalHistory: Int32 = 0
     var defaultTabIndex: Int32 = 3

--- a/HexaCalc/Model/TelemetryManager.swift
+++ b/HexaCalc/Model/TelemetryManager.swift
@@ -108,6 +108,7 @@ enum TelemetrySettingsAction: String {
     // Calculation history actions
     case History = "historyButtonViewChanged"
     case ClearHistory = "clearLocalHistory"
+    case HistoryEnabled = "historyEnabledSwitchPressed"
     // About the app actions
     case OpenSource = "openSourcePressed"
     case Share = "sharePressed"

--- a/HexaCalc/Model/UserPreferences.swift
+++ b/HexaCalc/Model/UserPreferences.swift
@@ -21,7 +21,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
     
     //Prepares and instance of a class for use
     init(colour: UIColor, colourNum: Int64, hexTabState: Bool, binTabState: Bool, decTabState: Bool, setCalculatorTextColour: Bool, copyActionIndex: Int32, pasteActionIndex: Int32,
-         historyButtonViewIndex: Int32, defaultTabIndex: Int32) {
+         historyButtonViewIndex: Int32, defaultTabIndex: Int32, historyEnabled: Bool = true) {
         //Initialize stored properties.
         self.colour = colour
         self.colourNum = colourNum
@@ -33,6 +33,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         self.pasteActionIndex = pasteActionIndex
         self.historyButtonViewIndex = historyButtonViewIndex
         self.defaultTabIndex = defaultTabIndex
+        self.historyEnabled = historyEnabled
     }
     
     //MARK: Properties
@@ -47,6 +48,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
     var pasteActionIndex: Int32
     var historyButtonViewIndex: Int32
     var defaultTabIndex: Int32
+    var historyEnabled: Bool
     
     //MARK: Archiving Paths
     
@@ -67,6 +69,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         static let pasteActionIndex = "pasteActionIndex"
         static let historyButtonViewIndex = "historyButtonViewIndex"
         static let defaultTabIndex = "defaultTabIndex"
+        static let historyEnabled = "historyEnabled"
     }
     
     //MARK: NSCoding
@@ -82,6 +85,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         aCoder.encode(pasteActionIndex, forKey: PropertyKey.pasteActionIndex)
         aCoder.encode(historyButtonViewIndex, forKey: PropertyKey.historyButtonViewIndex)
         aCoder.encode(defaultTabIndex, forKey: PropertyKey.defaultTabIndex)
+        aCoder.encode(historyEnabled, forKey: PropertyKey.historyEnabled)
     }
     
     required convenience init?(coder aDecoder: NSCoder) {
@@ -105,7 +109,15 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         let historyButtonViewIndex = aDecoder.decodeInt32(forKey: PropertyKey.historyButtonViewIndex)
         
         let defaultTabIndex = aDecoder.decodeInt32(forKey: PropertyKey.defaultTabIndex)
-        
+
+        // Default true for users upgrading from a version before historyEnabled was added
+        let historyEnabled: Bool
+        if aDecoder.containsValue(forKey: PropertyKey.historyEnabled) {
+            historyEnabled = aDecoder.decodeBool(forKey: PropertyKey.historyEnabled)
+        } else {
+            historyEnabled = true
+        }
+
         //Must call designated initializer
         self.init(
             colour: colour,
@@ -117,7 +129,8 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
             copyActionIndex: copyActionIndex,
             pasteActionIndex: pasteActionIndex,
             historyButtonViewIndex: historyButtonViewIndex,
-            defaultTabIndex: defaultTabIndex
+            defaultTabIndex: defaultTabIndex,
+            historyEnabled: historyEnabled
         )
     }
     

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -260,7 +260,7 @@ class BinaryViewController: CalculatorViewController {
 
             let unaryCalculationResult = labelValueBeforeSpaces == "" ? "0" : labelValueBeforeSpaces
             let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "1", operation: .LeftShift, result: unaryCalculationResult, isUnaryOperation: false)
-            calculationHistory.insert(calculationData, at: 0)
+            appendToHistory(calculationData)
         }
     }
 
@@ -292,7 +292,7 @@ class BinaryViewController: CalculatorViewController {
 
             let unaryCalculationResult = labelValueBeforeSpaces == "" ? "0" : labelValueBeforeSpaces
             let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "1", operation: .RightShift, result: unaryCalculationResult, isUnaryOperation: false)
-            calculationHistory.insert(calculationData, at: 0)
+            appendToHistory(calculationData)
         }
     }
 
@@ -322,7 +322,7 @@ class BinaryViewController: CalculatorViewController {
 
         let unaryCalculationResult = onesComplimentString == "" ? "0" : onesComplimentString
         let calculationData = CalculationData(leftValue: binLeftValue, rightValue: "", operation: .Not, result: unaryCalculationResult, isUnaryOperation: true)
-        calculationHistory.insert(calculationData, at: 0)
+        appendToHistory(calculationData)
 
         quickUpdateStateController()
     }
@@ -496,7 +496,7 @@ class BinaryViewController: CalculatorViewController {
                 updateOutputLabel(value: newLabelValue)
 
                 let calculationData = CalculationData(leftValue: leftBinValue, rightValue: rightBinValue, operation: operation, result: labelValueBeforeSpaces, isUnaryOperation: false)
-                calculationHistory.insert(calculationData, at: 0)
+                appendToHistory(calculationData)
 
                 rightBinValue = newLabelValue
             }

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -247,6 +247,13 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.CopyAndPaste)
     }
 
+    // MARK: History
+
+    func appendToHistory(_ entry: CalculationData) {
+        guard stateController?.convValues.historyEnabled ?? true else { return }
+        calculationHistory.insert(entry, at: 0)
+    }
+
     // MARK: UI helpers
 
     func setupCalculatorTextColour(state: Bool, colourToSet: UIColor) {

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -21,6 +21,7 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     var historyButton: UIButton!
     var historyButtonWidthConstraint: NSLayoutConstraint?
     var historyButtonHorizontalConstraint: NSLayoutConstraint?
+    var historyButtonTopConstraint: NSLayoutConstraint?
 
     // MARK: Shared state
     var stateController: StateController?
@@ -107,6 +108,9 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
             NSLayoutConstraint.deactivate(currentConstraints)
             currentConstraints.removeAll()
         }
+        coordinator.animate(alongsideTransition: { _ in
+            self.repositionHistoryButton(for: size)
+        })
     }
 
     // MARK: viewWillAppear helper

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -106,9 +106,6 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         if UIDevice.current.userInterfaceIdiom == .pad {
             NSLayoutConstraint.deactivate(currentConstraints)
             currentConstraints.removeAll()
-            coordinator.animate(alongsideTransition: { _ in
-                self.repositionHistoryButton(for: size)
-            })
         }
     }
 

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -20,6 +20,7 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     // MARK: HistoryButtonHost
     var historyButton: UIButton!
     var historyButtonWidthConstraint: NSLayoutConstraint?
+    var historyButtonHorizontalConstraint: NSLayoutConstraint?
 
     // MARK: Shared state
     var stateController: StateController?
@@ -105,6 +106,9 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         if UIDevice.current.userInterfaceIdiom == .pad {
             NSLayoutConstraint.deactivate(currentConstraints)
             currentConstraints.removeAll()
+            coordinator.animate(alongsideTransition: { _ in
+                self.repositionHistoryButton(for: size)
+            })
         }
     }
 

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -288,7 +288,7 @@ class DecimalViewController: CalculatorViewController {
                     if (Double(result)! > 999999999) {
                         let unaryCalculationResult = result == "" ? "0" : result
                         let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
-                        calculationHistory.insert(calculationData, at: 0)
+                        appendToHistory(calculationData)
                         leftValue = result
                         result = "\(Double(result)!.scientificFormatted)"
                         updateOutputLabel(value: result)
@@ -301,7 +301,7 @@ class DecimalViewController: CalculatorViewController {
 
                     let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
                     let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
-                    calculationHistory.insert(calculationData, at: 0)
+                    appendToHistory(calculationData)
                     leftValue = result
                     quickUpdateStateController()
                 }
@@ -335,7 +335,7 @@ class DecimalViewController: CalculatorViewController {
                 if (Double(result)! > 999999999) {
                     let unaryCalculationResult = result == "" ? "0" : result
                     let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
-                    calculationHistory.insert(calculationData, at: 0)
+                    appendToHistory(calculationData)
                     leftValue = result
                     result = "\(Double(result)!.scientificFormatted)"
                     updateOutputLabel(value: result)
@@ -348,7 +348,7 @@ class DecimalViewController: CalculatorViewController {
 
                 let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
                 let calculationData = CalculationData(leftValue: leftValue, rightValue: "", operation: .Sqrt, result: unaryCalculationResult, isUnaryOperation: true)
-                calculationHistory.insert(calculationData, at: 0)
+                appendToHistory(calculationData)
                 leftValue = result
                 quickUpdateStateController()
             }
@@ -481,7 +481,7 @@ class DecimalViewController: CalculatorViewController {
                 }
 
                 let calculationData = CalculationData(leftValue: leftValue, rightValue: rightValue, operation: currentOperation, result: result, isUnaryOperation: false)
-                calculationHistory.insert(calculationData, at: 0)
+                appendToHistory(calculationData)
 
                 leftValue = result
 

--- a/HexaCalc/View Controllers/HexaCalcTabBarController.swift
+++ b/HexaCalc/View Controllers/HexaCalcTabBarController.swift
@@ -37,6 +37,7 @@ class HexaCalcTabBarController: UITabBarController, StateControllerProtocol {
         stateController?.convValues.copyActionIndex = savedPreferences.copyActionIndex
         stateController?.convValues.pasteActionIndex = savedPreferences.pasteActionIndex
         stateController?.convValues.historyButtonViewIndex = savedPreferences.historyButtonViewIndex
+        stateController?.convValues.historyEnabled = savedPreferences.historyEnabled
         stateController?.convValues.defaultTabIndex = savedPreferences.defaultTabIndex
 
         // Remove disabled tabs before any child VC loads (avoids mutating viewControllers

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -272,7 +272,7 @@ class HexadecimalViewController: CalculatorViewController {
 
         let unaryCalculationResult = runningNumber == "" ? "0" : runningNumber
         let calculationData = CalculationData(leftValue: currentValue, rightValue: "", operation: .Not, result: unaryCalculationResult, isUnaryOperation: true)
-        calculationHistory.insert(calculationData, at: 0)
+        appendToHistory(calculationData)
 
         quickUpdateStateController()
     }
@@ -462,7 +462,7 @@ class HexadecimalViewController: CalculatorViewController {
                 updateOutputLabel(value: newLabelValue)
 
                 let calculationData = CalculationData(leftValue: rightHexValue, rightValue: leftHexValue, operation: currentOperation, result: newLabelValue, isUnaryOperation: false)
-                calculationHistory.insert(calculationData, at: 0)
+                appendToHistory(calculationData)
 
                 rightHexValue = newLabelValue
             }

--- a/HexaCalc/View Controllers/SettingsSelectionViewController.swift
+++ b/HexaCalc/View Controllers/SettingsSelectionViewController.swift
@@ -129,7 +129,8 @@ class SettingsSelectionViewController: UIViewController, UITableViewDelegate, UI
                                                       hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                                       setCalculatorTextColour: preferences.setCalculatorTextColour,
                                                       copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                                      historyEnabled: preferences.historyEnabled)
                     
                     // Set tab bar icon colour to new colour
                     tabBarController?.tabBar.tintColor = colour
@@ -158,7 +159,8 @@ class SettingsSelectionViewController: UIViewController, UITableViewDelegate, UI
                                                       hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                                       setCalculatorTextColour: preferences.setCalculatorTextColour,
                                                       copyActionIndex: Int32(index), pasteActionIndex: preferences.pasteActionIndex,
-                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                                      historyEnabled: preferences.historyEnabled)
                     stateController?.convValues.copyActionIndex = Int32(index)
                     
                     telemetryManager.sendSettingsSignal(
@@ -177,7 +179,8 @@ class SettingsSelectionViewController: UIViewController, UITableViewDelegate, UI
                                                       hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                                       setCalculatorTextColour: preferences.setCalculatorTextColour,
                                                       copyActionIndex: preferences.copyActionIndex, pasteActionIndex: Int32(index),
-                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                                      historyEnabled: preferences.historyEnabled)
                     stateController?.convValues.pasteActionIndex = Int32(index)
                     
                     telemetryManager.sendSettingsSignal(
@@ -196,7 +199,8 @@ class SettingsSelectionViewController: UIViewController, UITableViewDelegate, UI
                                                       hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                                       setCalculatorTextColour: preferences.setCalculatorTextColour,
                                                       copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                                      historyButtonViewIndex: Int32(index), defaultTabIndex: preferences.defaultTabIndex)
+                                                      historyButtonViewIndex: Int32(index), defaultTabIndex: preferences.defaultTabIndex,
+                                                      historyEnabled: preferences.historyEnabled)
                     stateController?.convValues.historyButtonViewIndex = Int32(index)
                     
                     telemetryManager.sendSettingsSignal(
@@ -215,7 +219,8 @@ class SettingsSelectionViewController: UIViewController, UITableViewDelegate, UI
                                                       hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                                       setCalculatorTextColour: preferences.setCalculatorTextColour,
                                                       copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: Int32(index))
+                                                      historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: Int32(index),
+                                                      historyEnabled: preferences.historyEnabled)
                     stateController?.convValues.defaultTabIndex = Int32(index)
                     
                     telemetryManager.sendSettingsSignal(

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -155,6 +155,14 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
 
         return nil
     }
+
+    // Setup section footers
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if section == 3 && !preferences.historyEnabled {
+            return "Enable Calculation History to configure the button appearance."
+        }
+        return nil
+    }
     
     // Build table cell layout
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -21,7 +21,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                           "Calculation History",
                           "About the app",
                           "Support" ]
-    let rowsPerSection = [4, 2, 2, 2, 4, 3]
+    let rowsPerSection = [4, 2, 2, 3, 4, 3]
     
     let supportURLs = [ "https://anthony55hopkins.wixsite.com/hexacalc/privacy-policy",
                         "https://anthony55hopkins.wixsite.com/hexacalc/terms-conditions" ]
@@ -234,18 +234,30 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             }
         // Calculation history section
         case 3:
-            // Select history button display preference
+            // History enabled toggle
             if indexPath.row == 0 {
+                let cell = self.tableView.dequeueReusableCell(withIdentifier: "HistorySwitch", for: indexPath) as! SwitchTableViewCell
+                cell.configure(isOn: preferences.historyEnabled, colour: self.preferences.colour)
+                cell.textLabel?.text = "Calculation History"
+                cell.self.cellSwitch.addTarget(self, action: #selector(self.historySwitchPressed), for: .touchUpInside)
+                return cell
+            }
+            // Select history button display preference
+            else if indexPath.row == 1 {
                 let cell = self.tableView.dequeueReusableCell(withIdentifier: "HistoryButtonSelection", for: indexPath) as! SelectionSummaryTableViewCell
                 cell.configure(rightText: HistoryButtonViewConverter.getViewFromIndex(index: Int(self.preferences.historyButtonViewIndex)), colour: UIColor.systemGray)
                 cell.textLabel?.text = "History Button View"
+                cell.isUserInteractionEnabled = preferences.historyEnabled
+                cell.alpha = preferences.historyEnabled ? 1.0 : 0.4
                 return cell
             }
             // Clear local history
             else {
                 let cell = self.tableView.dequeueReusableCell(withIdentifier: "ClearHistory", for: indexPath) as! TextTableViewCell
                 cell.textLabel?.text = "Clear Local History"
-                cell.textLabel?.textColor = preferences.colour
+                cell.textLabel?.textColor = preferences.historyEnabled ? preferences.colour : .systemGray
+                cell.isUserInteractionEnabled = preferences.historyEnabled
+                cell.alpha = preferences.historyEnabled ? 1.0 : 0.4
                 return cell
             }
         // About the app section
@@ -346,36 +358,37 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         }
         // Calculation history operations
         if indexPath.section == 3 {
+            // Row 0 is the history enabled switch — handled by IBAction, no navigation needed
             // Navigate to history button selection view
-            if indexPath.row == 0 {
+            if indexPath.row == 1 {
                 if let _ = tableView.cellForRow(at: indexPath), let destinationViewController = navigationController?.storyboard?.instantiateViewController(withIdentifier: SettingsSelectionViewController.identifier) as? SettingsSelectionViewController {
-                    destinationViewController.selectionList = ["Icon Image", "Text Label", "Off"]
+                    destinationViewController.selectionList = ["Icon Image", "Text Label"]
                     destinationViewController.preferences = self.preferences
                     destinationViewController.selectedIndex = Int(self.preferences.historyButtonViewIndex)
                     destinationViewController.selectionType = SelectionType.historyButtonView
                     destinationViewController.stateController = stateController
                     destinationViewController.name = "History Button View"
-                    
+
                     // Navigate to new view
                     navigationController?.pushViewController(destinationViewController, animated: true)
                 }
             }
             // Clear local history
-            else {
+            else if indexPath.row == 2 {
                 // Set the flag to 7 (111 in binary)
                 stateController?.convValues.clearLocalHistory = 7
-                
+
                 // Tell the user that the history was cleared
                 let alert = UIAlertController(title: "Local History Cleared", message: "The local calculation history for all calculators has been cleared.", preferredStyle: .alert)
-                
+
                 present(alert, animated: true) {
                     tableView.deselectRow(at: indexPath, animated: true)
                 }
-                
+
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                     alert.dismiss(animated: true, completion: nil)
                 }
-                
+
                 telemetryManager.sendSettingsSignal(
                     section: TelemetrySettingsSection.History,
                     action: TelemetrySettingsAction.ClearHistory
@@ -440,7 +453,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               hexTabState: sender.isOn, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                              historyEnabled: preferences.historyEnabled)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         (tabBarController as? HexaCalcTabBarController)?.setTab(0, enabled: sender.isOn)
         self.preferences = userPreferences
@@ -459,7 +473,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               hexTabState: preferences.hexTabState, binTabState: sender.isOn, decTabState: preferences.decTabState,
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                              historyEnabled: preferences.historyEnabled)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         (tabBarController as? HexaCalcTabBarController)?.setTab(1, enabled: sender.isOn)
         self.preferences = userPreferences
@@ -478,7 +493,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: sender.isOn,
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                              historyEnabled: preferences.historyEnabled)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         (tabBarController as? HexaCalcTabBarController)?.setTab(2, enabled: sender.isOn)
         self.preferences = userPreferences
@@ -498,7 +514,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
                                               setCalculatorTextColour: sender.isOn,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
-                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex)
+                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                              historyEnabled: preferences.historyEnabled)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         stateController?.convValues.setCalculatorTextColour = sender.isOn
         self.preferences = userPreferences
@@ -512,6 +529,30 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         )
     }
     
+    @IBAction func historySwitchPressed(_ sender: UISwitch) {
+        let userPreferences = UserPreferences(colour: preferences.colour, colourNum: (stateController?.convValues.colourNum)!,
+                                              hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
+                                              setCalculatorTextColour: preferences.setCalculatorTextColour,
+                                              copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
+                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                              historyEnabled: sender.isOn)
+        DataPersistence.savePreferences(userPreferences: userPreferences)
+        stateController?.convValues.historyEnabled = sender.isOn
+        if !sender.isOn {
+            stateController?.convValues.clearLocalHistory = 7
+        }
+        self.preferences = userPreferences
+        self.tableView.reloadSections([3], with: .none)
+
+        telemetryManager.sendSettingsSignal(
+            section: TelemetrySettingsSection.History,
+            action: TelemetrySettingsAction.HistoryEnabled,
+            parameters: [
+                "switchState": "\(sender.isOn)"
+            ]
+        )
+    }
+
     //MARK: Private functions
     
     // Prompt user to send feedback email

--- a/HexaCalcUITests/CalculationHistoryUITests.swift
+++ b/HexaCalcUITests/CalculationHistoryUITests.swift
@@ -16,6 +16,27 @@ class CalculationHistoryUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        let app = XCUIApplication()
+        guard app.tabBars["Tab Bar"].waitForExistence(timeout: 2) else { return }
+
+        app.tabBars["Tab Bar"].buttons["Settings"].tap()
+
+        // Re-enable history if a test left it disabled
+        let historySw = app.switches["Calculation History"]
+        if historySw.exists, (historySw.value as? String) == "0" {
+            historySw.tap()
+        }
+
+        // Restore History Button View to Icon Image if a test changed it
+        let historyButtonViewCell = app.tables.staticTexts["History Button View"]
+        if historyButtonViewCell.waitForExistence(timeout: 2) {
+            historyButtonViewCell.tap()
+            app.tables.staticTexts["Icon Image"].tap()
+            // If already on Icon Image the selection screen won't auto-pop — go back manually
+            if app.tables.staticTexts["Icon Image"].waitForExistence(timeout: 1) {
+                app.navigationBars.buttons["Settings"].tap()
+            }
+        }
     }
 
     func testCalculationHistoryButton() throws {
@@ -93,5 +114,134 @@ class CalculationHistoryUITests: XCTestCase {
 
         XCTAssert(app.alerts["Copied to clipboard"].waitForExistence(timeout: 4))
         // Alert auto-dismisses after 1.5 seconds — no button to tap
+    }
+
+    func testHistoryEnabledToggleHidesButton() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let tabBar = app.tabBars["Tab Bar"]
+
+        // Ensure history starts enabled
+        tabBar.buttons["Settings"].tap()
+        let historySw = app.switches["Calculation History"]
+        if (historySw.value as? String) == "0" { historySw.tap() }
+
+        // History button is visible on the Hexadecimal tab
+        tabBar.buttons["Hexadecimal"].tap()
+        let historyButton = app.buttons["History Button"]
+        XCTAssert(historyButton.waitForExistence(timeout: 2))
+        XCTAssert(historyButton.isHittable)
+
+        // Disable history — button should disappear
+        tabBar.buttons["Settings"].tap()
+        app.switches["Calculation History"].tap()
+        XCTAssertEqual(app.switches["Calculation History"].value as? String, "0")
+
+        tabBar.buttons["Hexadecimal"].tap()
+        XCTAssertFalse(app.buttons["History Button"].exists)
+
+        // Re-enable history — button should reappear
+        tabBar.buttons["Settings"].tap()
+        app.switches["Calculation History"].tap()
+        XCTAssertEqual(app.switches["Calculation History"].value as? String, "1")
+
+        tabBar.buttons["Hexadecimal"].tap()
+        XCTAssert(app.buttons["History Button"].waitForExistence(timeout: 2))
+        XCTAssert(app.buttons["History Button"].isHittable)
+    }
+
+    func testDisablingHistoryClearsAndStopsRecording() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let tabBar = app.tabBars["Tab Bar"]
+
+        // Ensure history starts enabled
+        tabBar.buttons["Settings"].tap()
+        let historySw = app.switches["Calculation History"]
+        if (historySw.value as? String) == "0" { historySw.tap() }
+
+        // Perform a calculation to populate history
+        tabBar.buttons["Hexadecimal"].tap()
+        app.buttons["A"].tap()
+        UITestHelper.add(app: app)
+        app.buttons["B"].tap()
+        UITestHelper.equals(app: app)
+
+        app.buttons["History Button"].tap()
+        XCTAssert(app.staticTexts["Calculation History"].waitForExistence(timeout: 2))
+        XCTAssert(app.tables.cells.count > 0)
+        app.buttons["close"].tap()
+
+        // Disable history — clears existing history
+        tabBar.buttons["Settings"].tap()
+        app.switches["Calculation History"].tap()
+        XCTAssertEqual(app.switches["Calculation History"].value as? String, "0")
+
+        // Perform more calculations while history is off
+        tabBar.buttons["Hexadecimal"].tap()
+        app.buttons["1"].tap()
+        UITestHelper.add(app: app)
+        app.buttons["2"].tap()
+        UITestHelper.equals(app: app)
+
+        // Re-enable history
+        tabBar.buttons["Settings"].tap()
+        app.switches["Calculation History"].tap()
+        XCTAssertEqual(app.switches["Calculation History"].value as? String, "1")
+
+        // History should be empty — cleared on disable, nothing recorded while off
+        tabBar.buttons["Hexadecimal"].tap()
+        app.buttons["History Button"].tap()
+        XCTAssert(app.staticTexts["Calculation History"].waitForExistence(timeout: 2))
+        XCTAssertEqual(app.tables.cells.count, 0)
+    }
+
+    func testHistoryButtonViewOnlyShowsTwoOptions() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.tabBars["Tab Bar"].buttons["Settings"].tap()
+
+        // Ensure history is enabled so the row is interactive
+        let historySw = app.switches["Calculation History"]
+        if (historySw.value as? String) == "0" { historySw.tap() }
+
+        app.tables.staticTexts["History Button View"].tap()
+
+        // Only Icon Image and Text Label should be present — Off was removed
+        XCTAssert(app.tables.staticTexts["Icon Image"].waitForExistence(timeout: 2))
+        XCTAssert(app.tables.staticTexts["Text Label"].exists)
+        XCTAssertFalse(app.tables.staticTexts["Off"].exists)
+
+        // Navigate back without making a change
+        app.navigationBars.buttons["Settings"].tap()
+    }
+
+    func testHistoryButtonViewTextLabel() throws {
+        let app = XCUIApplication()
+        app.launch()
+        let tabBar = app.tabBars["Tab Bar"]
+
+        // Ensure history is enabled
+        tabBar.buttons["Settings"].tap()
+        let historySw = app.switches["Calculation History"]
+        if (historySw.value as? String) == "0" { historySw.tap() }
+
+        // Switch button view to Text Label
+        app.tables.staticTexts["History Button View"].tap()
+        app.tables.staticTexts["Text Label"].tap()
+
+        // Confirm summary updated on Settings screen
+        XCTAssert(app.staticTexts["Text Label"].waitForExistence(timeout: 2))
+
+        // History button should still be visible and tappable on the Hexadecimal tab
+        tabBar.buttons["Hexadecimal"].tap()
+        let historyButton = app.buttons["History Button"]
+        XCTAssert(historyButton.waitForExistence(timeout: 2))
+        XCTAssert(historyButton.isHittable)
+
+        historyButton.tap()
+        XCTAssert(app.staticTexts["Calculation History"].waitForExistence(timeout: 2))
+        app.buttons["close"].tap()
     }
 }

--- a/HexaCalcUITests/CalculationHistoryUITests.swift
+++ b/HexaCalcUITests/CalculationHistoryUITests.swift
@@ -33,8 +33,8 @@ class CalculationHistoryUITests: XCTestCase {
             historyButtonViewCell.tap()
             app.tables.staticTexts["Icon Image"].tap()
             // If already on Icon Image the selection screen won't auto-pop — go back manually
-            if app.tables.staticTexts["Icon Image"].waitForExistence(timeout: 1) {
-                app.navigationBars.buttons["Settings"].tap()
+            if app.navigationBars["History Button View"].waitForExistence(timeout: 1) {
+                app.navigationBars["History Button View"].buttons["Settings"].tap()
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds a **Calculation History** toggle switch to the Settings screen (section 3, row 0); when off, no history is recorded across all three calculator tabs and any existing history is immediately cleared
- Removes the old **"Off"** option from the History Button View selection — the new toggle owns that concern — leaving only **Icon Image** and **Text Label** as button styles
- Introduces `appendToHistory(_:)` on the base `CalculatorViewController` to centralise the history-enabled guard, replacing all 11 direct `calculationHistory.insert` call sites across the three calculator VCs
- Backward-compatible: users upgrading from a version without `historyEnabled` in their archived preferences default to history enabled

## Test plan

- [x] Fresh install: history toggle is on, icon button visible, calculations populate history
- [x] Toggle history off: button hides, new calculations do not appear in history, existing history is cleared
- [x] Toggle history back on: button reappears, history starts accumulating again from scratch
- [x] History Button View selection only shows Icon Image and Text Label (no Off option)
- [x] All three calculator tabs (Hex, Binary, Decimal) respect the toggle
- [x] Existing preferences load correctly (upgrade path defaults to history enabled)
- [x] Existing UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)