### PR TITLE
Fix history button overlap on short iPhones and iPad mini landscape

### DIFF
--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -67,12 +67,7 @@ extension HistoryButtonHost where Self: UIViewController {
 
         historyButtonTopConstraint?.isActive = false
         let topConstraint: NSLayoutConstraint
-        if isLandscape && UIDevice.current.userInterfaceIdiom == .pad && size.height <= 768,
-           let anchorLabel = historyButtonAnchorLabel {
-            // iPad mini landscape (744–768pt tall) — label still sits near the top,
-            // same overlap as short iPhones; anchor below the label instead.
-            topConstraint = historyButton.topAnchor.constraint(equalTo: anchorLabel.bottomAnchor, constant: 8)
-        } else if isLandscape {
+        if isLandscape {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
         } else if size.height <= 736, let anchorLabel = historyButtonAnchorLabel {
             // Short iPhones (≤736pt: iPhone 8, SE, 7/8 Plus) in portrait.

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -67,11 +67,15 @@ extension HistoryButtonHost where Self: UIViewController {
 
         historyButtonTopConstraint?.isActive = false
         let topConstraint: NSLayoutConstraint
-        if isLandscape {
+        if isLandscape && UIDevice.current.userInterfaceIdiom == .pad && size.height <= 768,
+           let anchorLabel = historyButtonAnchorLabel {
+            // iPad mini landscape (744–768pt tall) — label still sits near the top,
+            // same overlap as short iPhones; anchor below the label instead.
+            topConstraint = historyButton.topAnchor.constraint(equalTo: anchorLabel.bottomAnchor, constant: 8)
+        } else if isLandscape {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
         } else if size.height <= 736, let anchorLabel = historyButtonAnchorLabel {
-            // On short iPhones (≤736pt: iPhone 8, SE, 7/8 Plus) the output label sits
-            // high enough that view.topAnchor+60 lands inside it — anchor below instead.
+            // Short iPhones (≤736pt: iPhone 8, SE, 7/8 Plus) in portrait.
             topConstraint = historyButton.topAnchor.constraint(equalTo: anchorLabel.bottomAnchor, constant: 8)
         } else {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60)

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -13,13 +13,14 @@ import UIKit
     var historyButtonWidthConstraint: NSLayoutConstraint? { get set }
     var historyButtonHorizontalConstraint: NSLayoutConstraint? { get set }
     var historyButtonTopConstraint: NSLayoutConstraint? { get set }
+    // Declared here (not just in the extension) so repositionHistoryButton
+    // gets dynamic dispatch and sees the CalculatorViewController override.
+    var historyButtonAnchorLabel: UILabel? { get }
     func historyButtonTapped()
 }
 
 extension HistoryButtonHost where Self: UIViewController {
 
-    // Subclasses that own an output label can return it here so
-    // repositionHistoryButton can anchor below it on short screens.
     var historyButtonAnchorLabel: UILabel? { nil }
 
     func presentHistory(calculationHistory: [CalculationData]) {

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -64,12 +64,12 @@ extension HistoryButtonHost where Self: UIViewController {
 
         historyButtonTopConstraint?.isActive = false
         let topConstraint: NSLayoutConstraint
-        if isLandscape || size.height <= 736 {
-            // Landscape (all devices) and short iPhone portrait (≤736pt: SE, 8, 7/8 Plus):
-            // anchor to safeAreaLayoutGuide so the button sits in the corner above the
-            // output label rather than through the middle of it (view.topAnchor+60) or
-            // below it (which would land inside the button grid on small screens).
+        if isLandscape {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
+        } else if size.height <= 736 {
+            // Short iPhone portrait (≤736pt: SE, 8, 7/8 Plus): tighter constant so the
+            // button sits flush in the top-right corner just below the status bar.
+            topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 4)
         } else {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60)
         }

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -18,6 +18,10 @@ import UIKit
 
 extension HistoryButtonHost where Self: UIViewController {
 
+    // Subclasses that own an output label can return it here so
+    // repositionHistoryButton can anchor below it on short screens.
+    var historyButtonAnchorLabel: UILabel? { nil }
+
     func presentHistory(calculationHistory: [CalculationData]) {
         guard let historyVC = storyboard?.instantiateViewController(withIdentifier: "CalculationHistoryViewController") as? CalculationHistoryViewController else { return }
         historyVC.calculationHistory = calculationHistory
@@ -65,6 +69,10 @@ extension HistoryButtonHost where Self: UIViewController {
         let topConstraint: NSLayoutConstraint
         if isLandscape {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
+        } else if size.height <= 736, let anchorLabel = historyButtonAnchorLabel {
+            // On short iPhones (≤736pt: iPhone 8, SE, 7/8 Plus) the output label sits
+            // high enough that view.topAnchor+60 lands inside it — anchor below instead.
+            topConstraint = historyButton.topAnchor.constraint(equalTo: anchorLabel.bottomAnchor, constant: 8)
         } else {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60)
         }

--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -13,15 +13,11 @@ import UIKit
     var historyButtonWidthConstraint: NSLayoutConstraint? { get set }
     var historyButtonHorizontalConstraint: NSLayoutConstraint? { get set }
     var historyButtonTopConstraint: NSLayoutConstraint? { get set }
-    // Declared here (not just in the extension) so repositionHistoryButton
-    // gets dynamic dispatch and sees the CalculatorViewController override.
-    var historyButtonAnchorLabel: UILabel? { get }
     func historyButtonTapped()
 }
 
 extension HistoryButtonHost where Self: UIViewController {
 
-    var historyButtonAnchorLabel: UILabel? { nil }
 
     func presentHistory(calculationHistory: [CalculationData]) {
         guard let historyVC = storyboard?.instantiateViewController(withIdentifier: "CalculationHistoryViewController") as? CalculationHistoryViewController else { return }
@@ -68,11 +64,12 @@ extension HistoryButtonHost where Self: UIViewController {
 
         historyButtonTopConstraint?.isActive = false
         let topConstraint: NSLayoutConstraint
-        if isLandscape {
+        if isLandscape || size.height <= 736 {
+            // Landscape (all devices) and short iPhone portrait (≤736pt: SE, 8, 7/8 Plus):
+            // anchor to safeAreaLayoutGuide so the button sits in the corner above the
+            // output label rather than through the middle of it (view.topAnchor+60) or
+            // below it (which would land inside the button grid on small screens).
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
-        } else if size.height <= 736, let anchorLabel = historyButtonAnchorLabel {
-            // Short iPhones (≤736pt: iPhone 8, SE, 7/8 Plus) in portrait.
-            topConstraint = historyButton.topAnchor.constraint(equalTo: anchorLabel.bottomAnchor, constant: 8)
         } else {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 60)
         }

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -77,6 +77,8 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         fatalError("Subclass must override updateThemeColour(_:)")
     }
 
+    var historyButtonAnchorLabel: UILabel? { outputLabel }
+
     var outputLabelAccessibilityIdentifier: String {
         fatalError("Subclass must override outputLabelAccessibilityIdentifier")
     }

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -77,8 +77,6 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         fatalError("Subclass must override updateThemeColour(_:)")
     }
 
-    var historyButtonAnchorLabel: UILabel? { outputLabel }
-
     var outputLabelAccessibilityIdentifier: String {
         fatalError("Subclass must override outputLabelAccessibilityIdentifier")
     }


### PR DESCRIPTION
## Summary

- On iPhone SE/8/7/8 Plus (≤736pt portrait), `view.topAnchor+60` landed through the middle of the output label. Now uses `safeAreaLayoutGuide.topAnchor+4` to tuck the button into the top-right corner just below the status bar.
- On all landscape orientations, uses `safeAreaLayoutGuide.topAnchor+8` (unchanged from prior fix).
- Taller iPhones (812pt+) retain the original `view.topAnchor+60` — no change for the majority of users.

## Test plan

- [x] iPhone SE / iPhone 8 simulator — portrait: button sits in top-right corner, clear of the output label and calculator buttons
- [x] iPhone SE / iPhone 8 simulator — landscape: button in top-right corner
- [x] iPhone 16 Pro simulator — portrait and landscape: unchanged behaviour
- [x] iPad mini simulator — landscape: button in top-right corner (safeArea+8)
- [x] iPad Air / iPad Pro simulator — portrait and landscape: unchanged behaviour
- [x] History button still tappable and opens history sheet on all tested devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)