### PR TITLE
Add telemetry opt-out toggle to Settings

### DIFF
--- a/HexaCalc/AppDelegate.swift
+++ b/HexaCalc/AppDelegate.swift
@@ -16,11 +16,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         // Initialize TelemetryDeck
-        
+        let telemetryEnabled = DataPersistence.loadPreferences()?.telemetryEnabled ?? true
+
         // Attempt to find App ID
         if let appID = Bundle.main.object(forInfoDictionaryKey: "HexaCalcAppID") {
             // Setup the singleton class
-            TelemetryManager.setup(TelemetryManager.TelemetryManagerConfig(appID: appID as! String))
+            TelemetryManager.setup(TelemetryManager.TelemetryManagerConfig(appID: appID as! String), enabled: telemetryEnabled)
         }
         
         // Override point for customization after application launch
@@ -54,7 +55,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             pasteActionIndex: loadedPreferences.pasteActionIndex,
                             historyButtonViewIndex: 0,
                             defaultTabIndex: 3,
-                            historyEnabled: loadedPreferences.historyEnabled
+                            historyEnabled: loadedPreferences.historyEnabled,
+                            telemetryEnabled: loadedPreferences.telemetryEnabled
                         )
                         DataPersistence.savePreferences(userPreferences: userPreferences)
                         UserDefaults.standard.set(appVersionNumber, forKey: "CurrentVersionNumber")
@@ -80,7 +82,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             pasteActionIndex: loadedPreferences.pasteActionIndex,
                             historyButtonViewIndex: 0,
                             defaultTabIndex: 3,
-                            historyEnabled: loadedPreferences.historyEnabled
+                            historyEnabled: loadedPreferences.historyEnabled,
+                            telemetryEnabled: loadedPreferences.telemetryEnabled
                         )
                         DataPersistence.savePreferences(userPreferences: userPreferences)
                         UITabBar.appearance().tintColor = UIColor.systemGreen

--- a/HexaCalc/Model/TelemetryManager.swift
+++ b/HexaCalc/Model/TelemetryManager.swift
@@ -17,6 +17,9 @@ class TelemetryManager {
     
     // Toggle for collecting telemetry data
     private static var telemetryOn: Bool?
+
+    // Set to true mid-session when the user toggles analytics off
+    var userDisabled: Bool = false
     
     // Structure for initializing the TelemetryManager
     struct TelemetryManagerConfig {
@@ -25,7 +28,11 @@ class TelemetryManager {
     
     private static var config: TelemetryManagerConfig?
     
-    class func setup(_ config: TelemetryManagerConfig) {
+    class func setup(_ config: TelemetryManagerConfig, enabled: Bool) {
+        guard enabled else {
+            telemetryOn = false
+            return
+        }
         TelemetryManager.config = config
     }
     
@@ -43,13 +50,13 @@ class TelemetryManager {
     }
     
     func sendCalculatorSignal(tab: TelemetryTab, action: TelemetryCalculatorAction) {
-        if TelemetryManager.telemetryOn ?? false {
+        if (TelemetryManager.telemetryOn ?? false) && !userDisabled {
             TelemetryDeck.signal(".\(tab).\(action)")
         }
     }
-    
+
     func sendSettingsSignal(section: TelemetrySettingsSection, action: TelemetrySettingsAction, parameters: [String : String]? = nil) {
-        if TelemetryManager.telemetryOn ?? false {
+        if (TelemetryManager.telemetryOn ?? false) && !userDisabled {
             if let params = parameters {
                 TelemetryDeck.signal(
                     ".\(TelemetryTab.Settings).\(section).\(action)",

--- a/HexaCalc/Model/TelemetryManager.swift
+++ b/HexaCalc/Model/TelemetryManager.swift
@@ -18,8 +18,7 @@ class TelemetryManager {
     // Toggle for collecting telemetry data
     private static var telemetryOn: Bool?
 
-    // Set to true mid-session when the user toggles analytics off
-    var userDisabled: Bool = false
+    var userTelemetryEnabled: Bool = true
     
     // Structure for initializing the TelemetryManager
     struct TelemetryManagerConfig {
@@ -50,13 +49,13 @@ class TelemetryManager {
     }
     
     func sendCalculatorSignal(tab: TelemetryTab, action: TelemetryCalculatorAction) {
-        if (TelemetryManager.telemetryOn ?? false) && !userDisabled {
+        if (TelemetryManager.telemetryOn ?? false) && userTelemetryEnabled {
             TelemetryDeck.signal(".\(tab).\(action)")
         }
     }
 
     func sendSettingsSignal(section: TelemetrySettingsSection, action: TelemetrySettingsAction, parameters: [String : String]? = nil) {
-        if (TelemetryManager.telemetryOn ?? false) && !userDisabled {
+        if (TelemetryManager.telemetryOn ?? false) && userTelemetryEnabled {
             if let params = parameters {
                 TelemetryDeck.signal(
                     ".\(TelemetryTab.Settings).\(section).\(action)",

--- a/HexaCalc/Model/UserPreferences.swift
+++ b/HexaCalc/Model/UserPreferences.swift
@@ -21,7 +21,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
     
     //Prepares and instance of a class for use
     init(colour: UIColor, colourNum: Int64, hexTabState: Bool, binTabState: Bool, decTabState: Bool, setCalculatorTextColour: Bool, copyActionIndex: Int32, pasteActionIndex: Int32,
-         historyButtonViewIndex: Int32, defaultTabIndex: Int32, historyEnabled: Bool = true) {
+         historyButtonViewIndex: Int32, defaultTabIndex: Int32, historyEnabled: Bool = true, telemetryEnabled: Bool = true) {
         //Initialize stored properties.
         self.colour = colour
         self.colourNum = colourNum
@@ -34,6 +34,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         self.historyButtonViewIndex = historyButtonViewIndex
         self.defaultTabIndex = defaultTabIndex
         self.historyEnabled = historyEnabled
+        self.telemetryEnabled = telemetryEnabled
     }
     
     //MARK: Properties
@@ -49,6 +50,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
     var historyButtonViewIndex: Int32
     var defaultTabIndex: Int32
     var historyEnabled: Bool
+    var telemetryEnabled: Bool
     
     //MARK: Archiving Paths
     
@@ -70,6 +72,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         static let historyButtonViewIndex = "historyButtonViewIndex"
         static let defaultTabIndex = "defaultTabIndex"
         static let historyEnabled = "historyEnabled"
+        static let telemetryEnabled = "telemetryEnabled"
     }
     
     //MARK: NSCoding
@@ -86,6 +89,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         aCoder.encode(historyButtonViewIndex, forKey: PropertyKey.historyButtonViewIndex)
         aCoder.encode(defaultTabIndex, forKey: PropertyKey.defaultTabIndex)
         aCoder.encode(historyEnabled, forKey: PropertyKey.historyEnabled)
+        aCoder.encode(telemetryEnabled, forKey: PropertyKey.telemetryEnabled)
     }
     
     required convenience init?(coder aDecoder: NSCoder) {
@@ -118,6 +122,14 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
             historyEnabled = true
         }
 
+        // Default true for users upgrading from a version before telemetryEnabled was added
+        let telemetryEnabled: Bool
+        if aDecoder.containsValue(forKey: PropertyKey.telemetryEnabled) {
+            telemetryEnabled = aDecoder.decodeBool(forKey: PropertyKey.telemetryEnabled)
+        } else {
+            telemetryEnabled = true
+        }
+
         //Must call designated initializer
         self.init(
             colour: colour,
@@ -130,7 +142,8 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
             pasteActionIndex: pasteActionIndex,
             historyButtonViewIndex: historyButtonViewIndex,
             defaultTabIndex: defaultTabIndex,
-            historyEnabled: historyEnabled
+            historyEnabled: historyEnabled,
+            telemetryEnabled: telemetryEnabled
         )
     }
     

--- a/HexaCalc/View Controllers/HexaCalcTabBarController.swift
+++ b/HexaCalc/View Controllers/HexaCalcTabBarController.swift
@@ -40,6 +40,8 @@ class HexaCalcTabBarController: UITabBarController, StateControllerProtocol {
         stateController?.convValues.historyEnabled = savedPreferences.historyEnabled
         stateController?.convValues.defaultTabIndex = savedPreferences.defaultTabIndex
 
+        TelemetryManager.sharedTelemetryManager.userDisabled = !savedPreferences.telemetryEnabled
+
         // Remove disabled tabs before any child VC loads (avoids mutating viewControllers
         // from within a child VC's own viewDidLoad, which crashes on iOS 26+)
         if !savedPreferences.hexTabState { setTab(0, enabled: false) }

--- a/HexaCalc/View Controllers/HexaCalcTabBarController.swift
+++ b/HexaCalc/View Controllers/HexaCalcTabBarController.swift
@@ -40,7 +40,7 @@ class HexaCalcTabBarController: UITabBarController, StateControllerProtocol {
         stateController?.convValues.historyEnabled = savedPreferences.historyEnabled
         stateController?.convValues.defaultTabIndex = savedPreferences.defaultTabIndex
 
-        TelemetryManager.sharedTelemetryManager.userDisabled = !savedPreferences.telemetryEnabled
+        TelemetryManager.sharedTelemetryManager.userTelemetryEnabled = savedPreferences.telemetryEnabled
 
         // Remove disabled tabs before any child VC loads (avoids mutating viewControllers
         // from within a child VC's own viewDidLoad, which crashes on iOS 26+)

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -20,8 +20,9 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                           "Customization",
                           "Calculation History",
                           "About the app",
-                          "Support" ]
-    let rowsPerSection = [4, 2, 2, 3, 4, 3]
+                          "Support",
+                          "Privacy" ]
+    let rowsPerSection = [4, 2, 2, 3, 4, 3, 1]
     
     let supportURLs = [ "https://anthony55hopkins.wixsite.com/hexacalc/privacy-policy",
                         "https://anthony55hopkins.wixsite.com/hexacalc/terms-conditions" ]
@@ -51,6 +52,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "BinarySwitch")
         table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "DecimalSwitch")
         table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "HistorySwitch")
+        table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "TelemetrySwitch")
         table.register(SelectionSummaryTableViewCell.self, forCellReuseIdentifier: "ColourSelection")
         table.register(SelectionSummaryTableViewCell.self, forCellReuseIdentifier: "CopyActionSelection")
         table.register(SelectionSummaryTableViewCell.self, forCellReuseIdentifier: "PasteActionSelection")
@@ -108,7 +110,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             self.preferences.colour = stateController?.convValues.colour ?? self.preferences.colour
             
             // Reload UI only when necessary
-            self.tableView.reloadSections([0,2,3,4], with: .none)
+            self.tableView.reloadSections([0,2,3,4,6], with: .none)
         }
         else if (self.preferences.copyActionIndex != stateController?.convValues.copyActionIndex) {
             self.preferences.copyActionIndex = stateController?.convValues.copyActionIndex ?? self.preferences.copyActionIndex
@@ -160,6 +162,9 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == 3 && !preferences.historyEnabled {
             return "Enable Calculation History to configure the button appearance."
+        }
+        if section == 6 {
+            return "Analytics are completely anonymous and contain no personal or identifiable information. They help prioritize future improvements. You can opt out at any time."
         }
         return nil
     }
@@ -314,11 +319,18 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                 cell.textLabel?.textColor = preferences.colour
                 return cell
             }
+        // Privacy section
+        case 6:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "TelemetrySwitch", for: indexPath) as! SwitchTableViewCell
+            cell.textLabel?.text = "Share Anonymous Analytics"
+            cell.configure(isOn: preferences.telemetryEnabled, colour: stateController?.convValues.colour ?? .systemGreen)
+            cell.cellSwitch.addTarget(self, action: #selector(telemetrySwitchChanged(_:)), for: .valueChanged)
+            return cell
         default:
             fatalError("Index out of range")
         }
     }
-    
+
     // method to run when table view cell is tapped
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // Override default selected tab
@@ -559,6 +571,12 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                 "switchState": "\(sender.isOn)"
             ]
         )
+    }
+
+    @objc func telemetrySwitchChanged(_ sender: UISwitch) {
+        preferences.telemetryEnabled = sender.isOn
+        DataPersistence.savePreferences(userPreferences: preferences)
+        TelemetryManager.sharedTelemetryManager.userDisabled = !sender.isOn
     }
 
     //MARK: Private functions

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -576,7 +576,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
     @objc func telemetrySwitchChanged(_ sender: UISwitch) {
         preferences.telemetryEnabled = sender.isOn
         DataPersistence.savePreferences(userPreferences: preferences)
-        TelemetryManager.sharedTelemetryManager.userDisabled = !sender.isOn
+        TelemetryManager.sharedTelemetryManager.userTelemetryEnabled = sender.isOn
     }
 
     //MARK: Private functions


### PR DESCRIPTION
## Summary
- Adds a **Privacy** section at the bottom of Settings with a \"Share Anonymous Analytics\" toggle
- When disabled at launch, the TelemetryDeck SDK is never initialized (no `AppLaunched` signal fires)
- When toggled off mid-session, `userDisabled` gates all further signals immediately
- Preference is persisted via `UserPreferences`; existing users upgrade with analytics on by default

## Test plan
- [x] Fresh install → toggle shows ON, TelemetryDeck receives signals including `AppLaunched`
- [x] Toggle OFF → force-quit → relaunch → no `AppLaunched` in TelemetryDeck (SDK never initialized)
- [x] Toggle OFF mid-session → subsequent calculator actions send no signals
- [x] Toggle back ON mid-session (was disabled at launch) → preference saved, no signals until next launch
- [x] Privacy section footer text visible below toggle without any tap
- [x] Upgrade from old prefs (no `telemetryEnabled` key) → toggle defaults to ON
- [x] `xcodebuild -scheme HexaCalc -project HexaCalc.xcodeproj test -only-testing HexaCalcUITests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)