### PR TITLE
Improve review prompt timing, API, and gating

### DIFF
--- a/HexaCalc/AppDelegate.swift
+++ b/HexaCalc/AppDelegate.swift
@@ -99,9 +99,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         
-        // Increment review worthy count on launch
-        ReviewManager.incrementReviewWorthyCount()
-        
         return true
     }
 

--- a/HexaCalc/Model/ReviewManager.swift
+++ b/HexaCalc/Model/ReviewManager.swift
@@ -15,46 +15,59 @@ import StoreKit
 class ReviewManager {
 
     static let minimumReviewWorthyActionCount = 3
-    
+
     static let reviewCountKey = "ReviewWorthyActionCount"
     static let reviewRequestVersionKey = "LastVersionReviewRequested"
-    
+    static let completedCalculationKey = "HasCompletedCalculation"
+
     static let productURLString = "https://apps.apple.com/app/id1529225315"
 
     static func incrementReviewWorthyCount() {
         let defaults = UserDefaults.standard
 
         var actionCount = defaults.integer(forKey: reviewCountKey)
-        
-        // Limit for requesting a review is 2, so no need to count past 3
+
         if actionCount < 3 {
             actionCount += 1
             defaults.set(actionCount, forKey: reviewCountKey)
         }
     }
-    
-    static func requestReviewIfAppropriate() {
-      let defaults = UserDefaults.standard
-      let bundle = Bundle.main
 
-      let actionCount = defaults.integer(forKey: reviewCountKey)
+    static func completedCalculation() {
+        let defaults = UserDefaults.standard
+        if !defaults.bool(forKey: completedCalculationKey) {
+            defaults.set(true, forKey: completedCalculationKey)
+        }
+    }
 
-      guard actionCount >= minimumReviewWorthyActionCount else {
-        return
-      }
+    // Returns true and commits side effects (reset count, record version) when a
+    // review prompt should be shown. Callers are responsible for the actual
+    // SKStoreReviewController call so UIKit stays out of this model file.
+    static func requestReviewIfAppropriate() -> Bool {
+        let defaults = UserDefaults.standard
+        let bundle = Bundle.main
 
-      let bundleVersionKey = kCFBundleVersionKey as String
-      let currentVersion = bundle.object(forInfoDictionaryKey: bundleVersionKey) as? String
-      let lastVersion = defaults.string(forKey: reviewRequestVersionKey)
+        guard defaults.bool(forKey: completedCalculationKey) else {
+            return false
+        }
 
-      guard lastVersion == nil || lastVersion != currentVersion else {
-        return
-      }
+        let actionCount = defaults.integer(forKey: reviewCountKey)
 
-      SKStoreReviewController.requestReview()
+        guard actionCount >= minimumReviewWorthyActionCount else {
+            return false
+        }
 
-      defaults.set(0, forKey: reviewCountKey)
-      defaults.set(currentVersion, forKey: reviewRequestVersionKey)
+        let bundleVersionKey = kCFBundleVersionKey as String
+        let currentVersion = bundle.object(forInfoDictionaryKey: bundleVersionKey) as? String
+        let lastVersion = defaults.string(forKey: reviewRequestVersionKey)
+
+        guard lastVersion == nil || lastVersion != currentVersion else {
+            return false
+        }
+
+        defaults.set(0, forKey: reviewCountKey)
+        defaults.set(currentVersion, forKey: reviewRequestVersionKey)
+        return true
     }
     
     static func getProductURL() -> URL {

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -392,6 +392,8 @@ class BinaryViewController: CalculatorViewController {
 
         telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
         ReviewManager.incrementReviewWorthyCount()
+        ReviewManager.completedCalculation()
+        requestReviewAfterCalculation()
     }
 
     //MARK: Private Functions

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -118,9 +118,13 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     }
 
     func requestReviewAfterCalculation() {
-        if ReviewManager.requestReviewIfAppropriate(),
-           let scene = view.window?.windowScene {
-            SKStoreReviewController.requestReview(in: scene)
+        guard ReviewManager.requestReviewIfAppropriate() else { return }
+        if #available(iOS 14.0, *) {
+            if let scene = view.window?.windowScene {
+                SKStoreReviewController.requestReview(in: scene)
+            }
+        } else {
+            SKStoreReviewController.requestReview()
         }
     }
 

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import StoreKit
 
 // Base class for all calculator tabs. Holds shared state, gesture handling,
 // clipboard actions, and lifecycle helpers. Subclasses provide the
@@ -114,7 +115,13 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
         )
         setupOutputLabelGestureRecognizers()
         overrideUserInterfaceStyle = .light
-        ReviewManager.requestReviewIfAppropriate()
+    }
+
+    func requestReviewAfterCalculation() {
+        if ReviewManager.requestReviewIfAppropriate(),
+           let scene = view.window?.windowScene {
+            SKStoreReviewController.requestReview(in: scene)
+        }
     }
 
 

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -266,6 +266,8 @@ class DecimalViewController: CalculatorViewController {
 
         telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
         ReviewManager.incrementReviewWorthyCount()
+        ReviewManager.completedCalculation()
+        requestReviewAfterCalculation()
     }
 
     @IBAction func plusPressed(_ sender: RoundButton) {

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -329,6 +329,8 @@ class HexadecimalViewController: CalculatorViewController {
 
         telemetryManager.sendCalculatorSignal(tab: telemetryTab, action: TelemetryCalculatorAction.Equals)
         ReviewManager.incrementReviewWorthyCount()
+        ReviewManager.completedCalculation()
+        requestReviewAfterCalculation()
     }
 
     //MARK: Private Functions

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -91,9 +91,6 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         // Set custom back button text to navigationItem
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "Settings", style: .plain, target: nil, action: nil)
         self.navigationController?.navigationBar.prefersLargeTitles = true
-        
-        // Launching settings is a review worthy action, request a review if appropriate
-        ReviewManager.requestReviewIfAppropriate()
     }
     
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
## Summary

- **Fix deprecated API**: Switch from `SKStoreReviewController.requestReview()` to the scene-based `requestReview(in:)`, which is the supported API since iOS 14
- **Better trigger timing**: Move prompt from `viewWillAppear` / Settings navigation to immediately after `equalsPressed` — fires at the moment the user has just seen a result, without interrupting calculation flow
- **Add a completion gate**: New `HasCompletedCalculation` flag in UserDefaults ensures the prompt can only appear after the user has actually performed a calculation, not just launched the app repeatedly (mirrors the `completedRoute` gate in Go Cycling)

## Architecture

`requestReviewIfAppropriate()` now returns `Bool` and stays UIKit-free. The new `requestReviewAfterCalculation()` helper on `CalculatorViewController` handles the scene lookup and `SKStoreReviewController` call, keeping UIKit out of the model layer.

## Test plan

- [x] Press `=` fewer than 3 times across sessions — confirm no prompt appears
- [x] Press `=` 3+ times — confirm prompt appears after an equals press, not on tab switch
- [x] After a prompt fires, press `=` repeatedly in the same app version — confirm it doesn't prompt again
- [x] Install a new version after a prior prompt — confirm the prompt can fire again once threshold is met

🤖 Generated with [Claude Code](https://claude.com/claude-code)