### PR TITLE
Add dynamic button resizing for all screen sizes and orientations

### DIFF
--- a/HexaCalc/Model/HistoryButtonHost.swift
+++ b/HexaCalc/Model/HistoryButtonHost.swift
@@ -61,10 +61,12 @@ extension HistoryButtonHost where Self: UIViewController {
 
         let size = targetSize ?? view.bounds.size
         let isLandscape = size.width > size.height
+        let isIPad = UIDevice.current.userInterfaceIdiom == .pad
 
         historyButtonTopConstraint?.isActive = false
         let topConstraint: NSLayoutConstraint
-        if isLandscape {
+
+        if isIPad || isLandscape {
             topConstraint = historyButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
         } else if size.height <= 736 {
             // Short iPhone portrait (≤736pt: SE, 8, 7/8 Plus): tighter constant so the

--- a/HexaCalc/Model/UIHelper.swift
+++ b/HexaCalc/Model/UIHelper.swift
@@ -9,223 +9,76 @@
 import Foundation
 import UIKit
 
-// Class of static helper functions for setting up the UI
+enum CalculatorLabelType {
+    case large, compact
+}
+
+struct CalculatorLayout {
+    let stackWidth: CGFloat
+    let hStackHeight: CGFloat
+    let vStackHeight: CGFloat
+    let singleButtonWidth: CGFloat
+    let doubleButtonWidth: CGFloat
+    let labelFontSize: CGFloat
+    let labelHeight: CGFloat
+    let labelToStackGap: CGFloat
+    let buttonFontSize: CGFloat
+    let cornerRadius: CGFloat
+}
+
 class UIHelper {
-    
-    // Setup calculator stack constraints
-    static func setupStackConstraints(hStacks: [UIStackView], vStack: UIStackView, outputLabel: UILabel, screenWidth: CGFloat) -> [NSLayoutConstraint] {
-        let stackWidth = screenWidth - 20
-        var hStackHeight: CGFloat = 0
-        var vStackHeight: CGFloat = 0
-    
-        var constraints = [NSLayoutConstraint]()
-        
-        // Hexadecimal calculator
-        if (hStacks.count == 6) {
-            hStackHeight = (stackWidth - 20)/5
-            vStackHeight = (hStackHeight * 6) + 25
+
+    static func calculateLayout(
+        width W: CGFloat,
+        height H: CGFloat,
+        rows nRows: Int,
+        cols nCols: Int,
+        labelType: CalculatorLabelType
+    ) -> CalculatorLayout {
+        let stackWidth = W - 20
+        let colSpacing: CGFloat = 5
+        let rowSpacing: CGFloat = 5
+
+        let labelFontSize: CGFloat
+        let labelHeight: CGFloat
+        if labelType == .large {
+            labelFontSize = min(W * 0.32, H * 0.18)
+            labelHeight = labelFontSize
+        } else {
+            labelFontSize = min(W * 0.08, H * 0.045)
+            labelHeight = labelFontSize * 2.5
         }
-        // Binary or Decimal calculator
-        else {
-            vStackHeight = (((stackWidth - 20)/5) * 6) + 25
-            hStackHeight = (vStackHeight - 20)/5
-        }
-        
-        for hStack in hStacks {
-            constraints.append(hStack.widthAnchor.constraint(equalToConstant: stackWidth))
-            constraints.append(hStack.heightAnchor.constraint(equalToConstant: hStackHeight))
-        }
-        
-        constraints.append(vStack.widthAnchor.constraint(equalToConstant: stackWidth))
-        constraints.append(vStack.heightAnchor.constraint(equalToConstant: vStackHeight))
-        constraints.append(vStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: 23.0))
-        
-        return constraints
-    }
-    
-    // Setup calculator button constraints
-    static func setupButtonConstraints(singleButtons: [RoundButton], doubleButtons: [RoundButton], screenWidth: CGFloat, calculator: Int) -> [NSLayoutConstraint] {
-        let stackWidth = screenWidth - 20
-        var singleButtonSize: CGFloat = 0
-        var doubleButtonSize: CGFloat = 0
-        var buttonFontSize: CGFloat = 0
-        
-        var constraints = [NSLayoutConstraint]()
-        
-        // Hexadecimal
-        if (calculator == 1) {
-            singleButtonSize = (stackWidth - 20)/5.0
-            doubleButtonSize = (singleButtonSize * 2) + 5
-            
-            // Scale button font size based on screen width
-            buttonFontSize = 27*(screenWidth/375)
-        }
-        // Binary or Decimal
-        else {
-            // Scale button font size based on screen width
-            buttonFontSize = 30*(screenWidth/375)
-            singleButtonSize = (((((stackWidth - 20)/5) * 6) + 25) - 20)/5
-            let buttonSpacing: CGFloat = (stackWidth - (singleButtonSize * 4))/3
-            doubleButtonSize = (singleButtonSize * 2) + buttonSpacing
-        }
-        
-        for button in singleButtons {
-            constraints.append(button.widthAnchor.constraint(equalToConstant: singleButtonSize))
-            constraints.append(button.heightAnchor.constraint(equalToConstant: singleButtonSize))
-            button.titleLabel?.font = UIFont.systemFont(ofSize: buttonFontSize, weight: .semibold)
-            button.layer.cornerRadius = singleButtonSize/2
-        }
-        
-        for button in doubleButtons {
-            constraints.append(button.widthAnchor.constraint(equalToConstant: doubleButtonSize))
-            constraints.append(button.heightAnchor.constraint(equalToConstant: singleButtonSize))
-            button.titleLabel?.font = UIFont.systemFont(ofSize: buttonFontSize, weight: .semibold)
-            button.layer.cornerRadius = singleButtonSize/2
-        }
-        
-        return constraints
-    }
-    
-    // Setup calculator label constraints
-    static func setupLabelConstraints(label: UILabel, screenWidth: CGFloat, calculator: Int) -> [NSLayoutConstraint] {
-        let labelWidth = screenWidth - 20
-        var labelHeight: CGFloat = 0
-        var labelFontSize: CGFloat = 0
-        
-        var constraints = [NSLayoutConstraint]()
-        
-        constraints.append(label.widthAnchor.constraint(equalToConstant: labelWidth))
-        
-        labelFontSize = (calculator == 2) ? 30*(screenWidth/375) : 120*(screenWidth/375)
-        labelHeight = (calculator == 2) ? (labelFontSize*2.5) : labelFontSize
-        
-        constraints.append(label.heightAnchor.constraint(equalToConstant: labelHeight))
-        
-        label.font = UIFont(name: "Avenir Next", size: labelFontSize)
-        
-        return constraints
-    }
-    
-    // Setup calculator stack constraints for iPad
-    static func iPadSetupStackConstraints(hStacks: [UIStackView], vStack: UIStackView, outputLabel: UILabel, screenWidth: CGFloat, screenHeight: CGFloat) -> [NSLayoutConstraint] {
-        var constraints = [NSLayoutConstraint]()
-        
-        // Use iPhone constraints if screen width is of that size
-        if (screenWidth < 415) {
-            constraints = setupStackConstraints(hStacks: hStacks, vStack: vStack, outputLabel: outputLabel, screenWidth: screenWidth)
-        }
-        else {
-            let stackWidth = screenWidth - 20
-            var vStackHeight = ((screenWidth * 2) > screenHeight) ? screenHeight/1.7 : screenHeight/1.75
-            var hStackHeight: CGFloat = 0
-            
-            // Vertical slide over needs special consideration
-            if ((screenWidth * 3) < screenHeight) {
-                vStackHeight = screenHeight/2.5
-            }
-            
-            // Hexadecimal calculator
-            if (hStacks.count == 6) {
-                hStackHeight = (vStackHeight - 25)/6
-            }
-            // Binary or Decimal calculator
-            else {
-                hStackHeight = (vStackHeight - 20)/5
-            }
-            
-            for hStack in hStacks {
-                constraints.append(hStack.widthAnchor.constraint(equalToConstant: stackWidth))
-                constraints.append(hStack.heightAnchor.constraint(equalToConstant: hStackHeight))
-            }
-            
-            constraints.append(vStack.widthAnchor.constraint(equalToConstant: stackWidth))
-            constraints.append(vStack.heightAnchor.constraint(equalToConstant: vStackHeight))
-            constraints.append(vStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: 10.0))
-        }
-        return constraints
-    }
-    
-    // Setup calculator button constraints for iPad
-    static func iPadSetupButtonConstraints(singleButtons: [RoundButton], doubleButtons: [RoundButton], screenWidth: CGFloat, screenHeight: CGFloat, calculator: Int) -> [NSLayoutConstraint] {
-        var constraints = [NSLayoutConstraint]()
-        
-        // Use iPhone constraints if screen width is of that size
-        if (screenWidth < 415) {
-            constraints = setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: calculator)
-        }
-        else {
-            let stackWidth = screenWidth - 20
-            var vStackHeight = ((screenWidth * 2) > screenHeight) ? screenHeight/1.7 : screenHeight/1.75
-            var buttonHeight: CGFloat = 0
-            var singleButtonWidth: CGFloat = 0
-            var doubleButtonWidth: CGFloat = 0
-            var buttonFontSize: CGFloat = 0
-            
-            // Vertical slide over needs special consideration
-            if ((screenWidth * 3) < screenHeight) {
-                vStackHeight = screenHeight/2.5
-            }
-            
-            // Hexadecimal
-            if (calculator == 1) {
-                buttonHeight = (vStackHeight - 25)/6
-                singleButtonWidth = (stackWidth - 40)/5.0
-                doubleButtonWidth = (singleButtonWidth * 2) + 10
-                
-                // Scale button font size based on screen width
-                buttonFontSize = 27*(min(screenHeight, screenWidth)/375)
-            }
-            // Binary or Decimal
-            else {
-                buttonHeight = (vStackHeight - 20)/5
-                singleButtonWidth = (stackWidth - 30)/4.0
-                doubleButtonWidth = (singleButtonWidth * 2) + 10
-                
-                // Scale button font size based on screen width
-                buttonFontSize = 30*(min(screenHeight, screenWidth)/375)
-            }
-            
-            for button in singleButtons {
-                constraints.append(button.widthAnchor.constraint(equalToConstant: singleButtonWidth))
-                constraints.append(button.heightAnchor.constraint(equalToConstant: buttonHeight))
-                button.layer.cornerRadius = ((screenWidth * 2) > screenHeight) ? buttonHeight/2 : buttonHeight/3
-                button.titleLabel?.font = UIFont.systemFont(ofSize: buttonFontSize, weight: .semibold)
-            }
-            
-            for button in doubleButtons {
-                constraints.append(button.widthAnchor.constraint(equalToConstant: doubleButtonWidth))
-                constraints.append(button.heightAnchor.constraint(equalToConstant: buttonHeight))
-                button.layer.cornerRadius = ((screenWidth * 2) > screenHeight) ? buttonHeight/2 : buttonHeight/3
-                button.titleLabel?.font = UIFont.systemFont(ofSize: buttonFontSize, weight: .semibold)
-            }
-        }
-        
-        return constraints
-    }
-    
-    // Setup calculator label constraints for iPads
-    static func iPadSetupLabelConstraints(label: UILabel, screenWidth: CGFloat, screenHeight: CGFloat, calculator: Int) -> [NSLayoutConstraint] {
-        let labelWidth = screenWidth - 20
-        var labelHeight: CGFloat = 0
-        var labelFontSize: CGFloat = 0
-        
-        var constraints = [NSLayoutConstraint]()
-        
-        // Use iPhone constraints if screen width is of that size
-        if (screenWidth < 415) {
-            constraints = setupLabelConstraints(label: label, screenWidth: screenWidth, calculator: calculator)
-        }
-        else {
-            constraints.append(label.widthAnchor.constraint(equalToConstant: labelWidth))
-            
-            labelFontSize = (calculator == 2) ? 30*(min(screenWidth, screenHeight)/375) : 90*(min(screenWidth, screenHeight)/375)
-            labelHeight = (calculator == 2) ? (labelFontSize*2.5) : labelFontSize
-            
-            constraints.append(label.heightAnchor.constraint(equalToConstant: labelHeight))
-            
-            label.font = UIFont(name: "Avenir Next", size: labelFontSize)
-        }
-        
-        return constraints
+
+        let labelToStackGap: CGFloat = 23
+
+        let usedHeight = labelHeight + labelToStackGap
+        let availableH = H * 0.95 - usedHeight
+
+        let verticalSpacing = CGFloat(nRows - 1) * rowSpacing
+        let horizontalSpacing = CGFloat(nCols - 1) * colSpacing
+
+        let btnFromWidth  = (stackWidth - horizontalSpacing) / CGFloat(nCols)
+        let btnFromHeight = (availableH - verticalSpacing) / CGFloat(nRows)
+        let buttonWidth   = max(btnFromWidth, 20)
+        let buttonHeight  = max(btnFromHeight, 20)
+
+        let vStackHeight = buttonHeight * CGFloat(nRows) + verticalSpacing
+        let doubleButtonWidth = buttonWidth * 2 + colSpacing
+        let cornerRadius = buttonHeight / 2
+
+        let buttonFontSize = (labelType == .large ? 27.0 : 30.0) * (buttonHeight / 67.0)
+
+        return CalculatorLayout(
+            stackWidth: stackWidth,
+            hStackHeight: buttonHeight,
+            vStackHeight: vStackHeight,
+            singleButtonWidth: buttonWidth,
+            doubleButtonWidth: doubleButtonWidth,
+            labelFontSize: labelFontSize,
+            labelHeight: labelHeight,
+            labelToStackGap: labelToStackGap,
+            buttonFontSize: buttonFontSize,
+            cornerRadius: cornerRadius
+        )
     }
 }

--- a/HexaCalc/Model/UIHelper.swift
+++ b/HexaCalc/Model/UIHelper.swift
@@ -15,6 +15,7 @@ enum CalculatorLabelType {
 
 struct CalculatorLayout {
     let stackWidth: CGFloat
+    let outputLabelWidth: CGFloat
     let hStackHeight: CGFloat
     let vStackHeight: CGFloat
     let singleButtonWidth: CGFloat
@@ -33,12 +34,15 @@ class UIHelper {
         height H: CGFloat,
         rows nRows: Int,
         cols nCols: Int,
-        labelType: CalculatorLabelType
+        labelType: CalculatorLabelType,
+        targetGridHeight: CGFloat? = nil,
+        isIPad: Bool = false
     ) -> CalculatorLayout {
-        let stackWidth = W - 20
+        let naturalStackWidth = W - 20
         let colSpacing: CGFloat = 5
         let rowSpacing: CGFloat = 5
 
+        // Label sizing for this tab
         let labelFontSize: CGFloat
         let labelHeight: CGFloat
         if labelType == .large {
@@ -50,26 +54,61 @@ class UIHelper {
         }
 
         let labelToStackGap: CGFloat = 23
-
-        let usedHeight = labelHeight + labelToStackGap
-        let availableH = H * 0.95 - usedHeight
+        let bottomPadding: CGFloat = 8
+        let topLabelPadding: CGFloat = 8
+        let availableH = H - labelHeight - labelToStackGap - bottomPadding - topLabelPadding
 
         let verticalSpacing = CGFloat(nRows - 1) * rowSpacing
         let horizontalSpacing = CGFloat(nCols - 1) * colSpacing
 
-        let btnFromWidth  = (stackWidth - horizontalSpacing) / CGFloat(nCols)
+        let btnFromWidth  = (naturalStackWidth - horizontalSpacing) / CGFloat(nCols)
         let btnFromHeight = (availableH - verticalSpacing) / CGFloat(nRows)
-        let buttonWidth   = max(btnFromWidth, 20)
-        let buttonHeight  = max(btnFromHeight, 20)
+
+        let buttonHeight: CGFloat
+        let buttonWidth: CGFloat
+
+        if isIPad {
+            // iPad: fill available width and height independently, allowing rectangular buttons.
+            if let target = targetGridHeight {
+                buttonHeight = max((target - verticalSpacing) / CGFloat(nRows), 20)
+                buttonWidth  = max(btnFromWidth, 20)
+            } else {
+                buttonHeight = max(btnFromHeight, 20)
+                buttonWidth  = max(btnFromWidth, 20)
+            }
+        } else {
+            // iPhone: square buttons sized by the tighter dimension.
+            if let target = targetGridHeight {
+                buttonHeight = max((target - verticalSpacing) / CGFloat(nRows), 20)
+                buttonWidth  = max(min(btnFromWidth, buttonHeight), 20)
+            } else {
+                let size = max(min(btnFromWidth, btnFromHeight), 20)
+                buttonHeight = size
+                buttonWidth  = size
+            }
+        }
 
         let vStackHeight = buttonHeight * CGFloat(nRows) + verticalSpacing
+        let stackWidth = buttonWidth * CGFloat(nCols) + colSpacing * CGFloat(nCols - 1)
         let doubleButtonWidth = buttonWidth * 2 + colSpacing
-        let cornerRadius = buttonHeight / 2
+        // Use min(w,h)/2 so square buttons stay circular and rectangular buttons get pill corners.
+        let cornerRadius = min(buttonWidth, buttonHeight) / 2
 
-        let buttonFontSize = (labelType == .large ? 27.0 : 30.0) * (buttonHeight / 67.0)
+        // Fixed base (independent of labelType) so button text is the same size
+        // across tabs for a given button size — previously Binary (.compact, 30pt
+        // base) rendered noticeably larger text than Hex/Decimal (.large, 27pt base)
+        // even when their buttons were the same size.
+        let buttonFontSize = 27.0 * (min(buttonWidth, buttonHeight) / 67.0)
+
+        // On iPad the history button sits in the top-right corner (44pt wide, 16pt from safe
+        // trailing, 8pt gap). The label is centered in the view, so its right edge =
+        // W/2 + labelWidth/2. To clear the button: labelWidth = W - 2*safeRight - 136.
+        // We approximate safeRight ≈ 0 and use W - 136, capped at stackWidth.
+        let outputLabelWidth = isIPad ? min(stackWidth, W - 136) : stackWidth
 
         return CalculatorLayout(
             stackWidth: stackWidth,
+            outputLabelWidth: outputLabelWidth,
             hStackHeight: buttonHeight,
             vStackHeight: vStackHeight,
             singleButtonWidth: buttonWidth,

--- a/HexaCalc/Model/UIHelper.swift
+++ b/HexaCalc/Model/UIHelper.swift
@@ -26,9 +26,25 @@ struct CalculatorLayout {
     let buttonFontSize: CGFloat
     let cornerRadius: CGFloat
     let topPadding: CGFloat
+    let binaryLineCount: Int
 }
 
 class UIHelper {
+
+    // The label's available width on iPad: clears the top-right history button (fixed
+    // 136pt clearance, negligible on a full-size iPad but a large fraction of a narrow
+    // resized window) without ever shrinking below 80% of the grid's own width
+    // (naturalStackWidth == the eventual stackWidth exactly, since the per-button width
+    // division has no remainder — see calculateLayout). Used both to size the label's
+    // actual width constraint and to fit Binary's compact-label font to that same width,
+    // so the two can never drift apart the way they did when the font fit a stale,
+    // narrower estimate while the box itself had already widened.
+    private static func iPadLabelWidthBudget(width W: CGFloat) -> CGFloat {
+        let stackWidth = W - 20
+        let cappedByHistoryButton = W - 136
+        let minLabelWidth = stackWidth * 0.80
+        return max(min(stackWidth, cappedByHistoryButton), minLabelWidth)
+    }
 
     static func calculateLayout(
         width W: CGFloat,
@@ -46,24 +62,47 @@ class UIHelper {
         // Label sizing for this tab
         let labelFontSize: CGFloat
         let labelHeight: CGFloat
+        let binaryLineCount: Int
         if labelType == .large {
             labelFontSize = min(W * 0.32, H * 0.18)
             labelHeight = labelFontSize
+            binaryLineCount = 2
         } else if isIPad {
-            // iPad: Binary's text is now always exactly two lines of 32 bits each
-            // (see formatBinaryString), so the font can be sized to actually fill
-            // the label's width instead of the fixed ratio below, which was tuned
-            // for iPhone's much narrower screen and left iPad's text tiny.
-            let approxLabelWidth = max(W - 136, 20)
-            let sampleLine = "0000 0000 0000 0000 0000 0000 0000 0000"
+            // iPad: Binary's 64-bit string is grouped into 4-bit nibbles ("0000") and
+            // can be split across more lines than the usual 2 (32 bits each) to fit
+            // narrow windows — halving the characters on a line roughly doubles the
+            // font size that still fits the available width. Stick with 2 lines as
+            // long as that stays legible; only split further once 2 lines would render
+            // below a readable size. Full-size iPads never come close to that floor
+            // (measured 29-40+pt even at 2 lines there), so their layout — and the
+            // traditional 2-line look — is completely unaffected; this only kicks in
+            // on windows narrow enough that 2 lines alone can't stay legible (e.g. an
+            // iPhone-width resized "Designed for iPad" window).
+            let approxLabelWidth = max(iPadLabelWidthBudget(width: W), 20)
             let font = UIFont(name: "Avenir Next", size: 100) ?? UIFont.systemFont(ofSize: 100)
-            let measuredWidth = (sampleLine as NSString).size(withAttributes: [.font: font]).width
-            let widthFitSize = measuredWidth > 0 ? (approxLabelWidth * 0.97) / measuredWidth * 100 : 44
-            labelFontSize = min(widthFitSize, H * 0.14)
-            labelHeight = labelFontSize * 2.5
+            let totalNibbles = 16
+            let minLegibleFontSize: CGFloat = 20
+            let lineCountCandidates = [2, 4, 8]
+            var candidateLineCount = lineCountCandidates.last!
+            var candidateFontSize: CGFloat = 44
+            for lineCount in lineCountCandidates {
+                let nibblesPerLine = totalNibbles / lineCount
+                let sampleLine = Array(repeating: "0000", count: nibblesPerLine).joined(separator: " ")
+                let measuredWidth = (sampleLine as NSString).size(withAttributes: [.font: font]).width
+                let widthFitSize = measuredWidth > 0 ? (approxLabelWidth * 0.97) / measuredWidth * 100 : 44
+                candidateFontSize = min(widthFitSize, H * 0.14)
+                candidateLineCount = lineCount
+                if candidateFontSize >= minLegibleFontSize {
+                    break
+                }
+            }
+            labelFontSize = candidateFontSize
+            labelHeight = labelFontSize * 1.25 * CGFloat(candidateLineCount)
+            binaryLineCount = candidateLineCount
         } else {
             labelFontSize = min(W * 0.08, H * 0.045)
             labelHeight = labelFontSize * 2.5
+            binaryLineCount = 2
         }
 
         let labelToStackGap: CGFloat = 23
@@ -102,14 +141,25 @@ class UIHelper {
         let buttonWidth: CGFloat
 
         if isIPad {
-            // iPad: fill available width and height independently, allowing rectangular buttons.
+            // iPad: fill available width and height independently, allowing rectangular
+            // buttons. Landscape windows naturally produce much wider-than-tall buttons
+            // (measured as low as ~0.4 height:width on a full-screen 13" iPad landscape)
+            // — that's normal and must stay unconstrained. But height stretching far past
+            // width is pathological: it's never seen in full-screen portrait or landscape
+            // (measured up to ~0.88 there), only in narrow/tall resized windows, and it's
+            // what makes buttons look like tall pills with tiny text (font size below
+            // tracks the smaller dimension). Cap only that one direction, with real
+            // headroom above the measured full-screen ceiling so no real device is affected.
+            let rawHeight: CGFloat
             if let target = targetGridHeight {
-                buttonHeight = max((target - verticalSpacing) / CGFloat(nRows), 20)
-                buttonWidth  = max(btnFromWidth, 20)
+                rawHeight = max((target - verticalSpacing) / CGFloat(nRows), 20)
             } else {
-                buttonHeight = max(btnFromHeight, 20)
-                buttonWidth  = max(btnFromWidth, 20)
+                rawHeight = max(btnFromHeight, 20)
             }
+            let rawWidth = max(btnFromWidth, 20)
+            let maxHeightOverWidth: CGFloat = 1.3
+            buttonWidth = rawWidth
+            buttonHeight = min(rawHeight, rawWidth * maxHeightOverWidth)
         } else {
             // iPhone: square buttons sized by the tighter dimension.
             if let target = targetGridHeight {
@@ -134,11 +184,14 @@ class UIHelper {
         // even when their buttons were the same size.
         let buttonFontSize = 27.0 * (min(buttonWidth, buttonHeight) / 67.0)
 
-        // On iPad the history button sits in the top-right corner (44pt wide, 16pt from safe
-        // trailing, 8pt gap). The label is centered in the view, so its right edge =
-        // W/2 + labelWidth/2. To clear the button: labelWidth = W - 2*safeRight - 136.
-        // We approximate safeRight ≈ 0 and use W - 136, capped at stackWidth.
-        let outputLabelWidth = isIPad ? min(stackWidth, W - 136) : stackWidth
+        // Hex/Decimal's right-aligned text should sit flush with the grid's true right
+        // edge (matching the button column above it), so their label always gets the
+        // full stackWidth — their font (the .large formula above) doesn't depend on
+        // label width at all, so widening the box is purely cosmetic here, no sizing
+        // side effects. Binary's compact-iPad font, by contrast, is fit directly to
+        // iPadLabelWidthBudget (see above) to choose its line count/font size, so its
+        // box width must keep matching that same budget or the two drift apart again.
+        let outputLabelWidth = (isIPad && labelType == .compact) ? iPadLabelWidthBudget(width: W) : stackWidth
 
         return CalculatorLayout(
             stackWidth: stackWidth,
@@ -152,7 +205,8 @@ class UIHelper {
             labelToStackGap: labelToStackGap,
             buttonFontSize: buttonFontSize,
             cornerRadius: cornerRadius,
-            topPadding: topLabelPadding
+            topPadding: topLabelPadding,
+            binaryLineCount: binaryLineCount
         )
     }
 

--- a/HexaCalc/Model/UIHelper.swift
+++ b/HexaCalc/Model/UIHelper.swift
@@ -25,6 +25,7 @@ struct CalculatorLayout {
     let labelToStackGap: CGFloat
     let buttonFontSize: CGFloat
     let cornerRadius: CGFloat
+    let topPadding: CGFloat
 }
 
 class UIHelper {
@@ -48,6 +49,18 @@ class UIHelper {
         if labelType == .large {
             labelFontSize = min(W * 0.32, H * 0.18)
             labelHeight = labelFontSize
+        } else if isIPad {
+            // iPad: Binary's text is now always exactly two lines of 32 bits each
+            // (see formatBinaryString), so the font can be sized to actually fill
+            // the label's width instead of the fixed ratio below, which was tuned
+            // for iPhone's much narrower screen and left iPad's text tiny.
+            let approxLabelWidth = max(W - 136, 20)
+            let sampleLine = "0000 0000 0000 0000 0000 0000 0000 0000"
+            let font = UIFont(name: "Avenir Next", size: 100) ?? UIFont.systemFont(ofSize: 100)
+            let measuredWidth = (sampleLine as NSString).size(withAttributes: [.font: font]).width
+            let widthFitSize = measuredWidth > 0 ? (approxLabelWidth * 0.97) / measuredWidth * 100 : 44
+            labelFontSize = min(widthFitSize, H * 0.14)
+            labelHeight = labelFontSize * 2.5
         } else {
             labelFontSize = min(W * 0.08, H * 0.045)
             labelHeight = labelFontSize * 2.5
@@ -55,7 +68,28 @@ class UIHelper {
 
         let labelToStackGap: CGFloat = 23
         let bottomPadding: CGFloat = 8
-        let topLabelPadding: CGFloat = 8
+        // Reserve enough room above the label so it clears the top-pinned history
+        // button (see HistoryButtonHost.repositionHistoryButton) instead of the grid
+        // simply filling all the way up to a flat 8pt floor. On iPad, and on iPhone in
+        // landscape or on short portrait screens (SE, 8, 7/8 Plus), the button sits
+        // right under the safe area (offset 8 on iPad/landscape, 4 on short portrait)
+        // — without this, a tall grid could push the label's fixed-height frame up
+        // underneath the button. Tall iPhone portraits pin the button well below the
+        // label already (view.topAnchor + 60), so the flat floor is left as-is there.
+        let topLabelPadding: CGFloat
+        if isIPad {
+            topLabelPadding = 56
+        } else {
+            let isLandscape = W > H
+            if isLandscape || H <= 736 {
+                let historyButtonTopOffset: CGFloat = isLandscape ? 8 : 4
+                let historyButtonHeight: CGFloat = 44
+                let gap: CGFloat = 8
+                topLabelPadding = historyButtonTopOffset + historyButtonHeight + gap
+            } else {
+                topLabelPadding = 8
+            }
+        }
         let availableH = H - labelHeight - labelToStackGap - bottomPadding - topLabelPadding
 
         let verticalSpacing = CGFloat(nRows - 1) * rowSpacing
@@ -117,7 +151,29 @@ class UIHelper {
             labelHeight: labelHeight,
             labelToStackGap: labelToStackGap,
             buttonFontSize: buttonFontSize,
-            cornerRadius: cornerRadius
+            cornerRadius: cornerRadius,
+            topPadding: topLabelPadding
         )
+    }
+
+    // On iPad, Binary/Decimal/Hex are forced to share one grid height so the button
+    // grids match, but each tab's own label height differs, so the leftover slack
+    // between the (label + gap + grid) block and the safe area varies per tab. Hex
+    // and Decimal size their own label with the same formula used to compute the
+    // shared grid height, so their content always fills the safe area exactly (zero
+    // slack) — the grid sits flush against bottomPadding regardless of this function.
+    // Binary's label uses a different (shorter, in tall/narrow windows) formula, so
+    // it alone can end up with real slack. Giving that slack to the bottom would
+    // pull Binary's grid away from the tab bar while Hex/Decimal's stays flush,
+    // visibly inconsistent between tabs — so all of it goes above the label instead,
+    // keeping the grid's bottom edge aligned with the other two tabs. iPhone is
+    // untouched — it always returns the original fixed padding.
+    static func verticalOffsets(safeHeight: CGFloat, layout: CalculatorLayout, isIPad: Bool) -> (top: CGFloat, bottom: CGFloat) {
+        let bottomPadding: CGFloat = 8
+        guard isIPad else { return (layout.topPadding, bottomPadding) }
+
+        let contentHeight = layout.labelHeight + layout.labelToStackGap + layout.vStackHeight
+        let slack = max(safeHeight - contentHeight - layout.topPadding - bottomPadding, 0)
+        return (layout.topPadding + slack, bottomPadding)
     }
 }

--- a/HexaCalc/Resources/Storyboards/Base.lproj/Main.storyboard
+++ b/HexaCalc/Resources/Storyboards/Base.lproj/Main.storyboard
@@ -467,9 +467,7 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="e8g-mp-jBB" firstAttribute="bottom" secondItem="4da-24-9uX" secondAttribute="bottomMargin" id="Qox-fa-Lxj"/>
                                     <constraint firstItem="Z7g-zo-MXa" firstAttribute="centerX" secondItem="e8g-mp-jBB" secondAttribute="centerX" id="Shr-A0-ioB"/>
-                                    <constraint firstItem="e8g-mp-jBB" firstAttribute="top" secondItem="Z7g-zo-MXa" secondAttribute="bottom" priority="250" constant="23" id="T3G-Qs-Vvf"/>
                                     <constraint firstItem="e8g-mp-jBB" firstAttribute="centerX" secondItem="4da-24-9uX" secondAttribute="centerX" id="Yf6-At-zWt"/>
                                 </constraints>
                             </view>
@@ -906,8 +904,6 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="55i-hd-IgX" firstAttribute="centerX" secondItem="HKc-mO-UCF" secondAttribute="centerX" id="1i1-53-J7H"/>
-                                    <constraint firstItem="55i-hd-IgX" firstAttribute="top" secondItem="c3H-nl-HbE" secondAttribute="bottom" priority="250" constant="23" id="XBA-3T-MJ9"/>
-                                    <constraint firstItem="55i-hd-IgX" firstAttribute="bottom" secondItem="HKc-mO-UCF" secondAttribute="bottomMargin" id="YdW-OG-G2P"/>
                                     <constraint firstItem="c3H-nl-HbE" firstAttribute="centerX" secondItem="55i-hd-IgX" secondAttribute="centerX" id="ch3-Ke-rPy"/>
                                 </constraints>
                             </view>
@@ -1281,8 +1277,6 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="YRn-jp-boy" firstAttribute="top" secondItem="a2J-4m-Np0" secondAttribute="bottom" priority="250" constant="23" id="4Mn-Si-XTX"/>
-                                    <constraint firstItem="YRn-jp-boy" firstAttribute="bottom" secondItem="2gC-fg-Gz8" secondAttribute="bottomMargin" id="HbO-rU-dvK"/>
                                     <constraint firstItem="a2J-4m-Np0" firstAttribute="centerX" secondItem="YRn-jp-boy" secondAttribute="centerX" id="ZtP-6E-lmq"/>
                                     <constraint firstItem="YRn-jp-boy" firstAttribute="centerX" secondItem="2gC-fg-Gz8" secondAttribute="centerX" id="kvT-4s-uJk"/>
                                 </constraints>

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -94,37 +94,55 @@ class BinaryViewController: CalculatorViewController {
         setupCommonViewDidLoad()
     }
 
-    override func viewDidLayoutSubviews() {
-        let screenWidth = view.bounds.width
-        let screenHeight = view.bounds.height
+    override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
+        let safeInsets = view.safeAreaInsets
+        let safeHeight = height - safeInsets.top - safeInsets.bottom
+        let topReserve: CGFloat = 80
+        let layout = UIHelper.calculateLayout(width: width, height: safeHeight - topReserve,
+                                              rows: 5, cols: 4, labelType: .compact)
+        var c = [NSLayoutConstraint]()
 
-        let hStacks = [binHStack1!, binHStack2!, binHStack3!, binHStack4!, binHStack5!]
-        let singleButtons = [DIVBtn!, MULTBtn!, SUBBtn!, PLUSBtn!, EQUALSBtn!, DELBtn!, XORBtn!, ORBtn!, ANDBtn!, NOTBtn!,
-                             ONESBtn!, TWOSBtn!, LSBtn!, RSBtn!, Btn0!, Btn1!, Btn00!, Btn11!]
-        let doubleButtons = [ACBtn!]
+        c += [
+            binVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            binVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
+            binVStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: layout.labelToStackGap)
+        ]
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: binVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
-            currentConstraints.append(contentsOf: stackConstraints)
-
-            let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
-            currentConstraints.append(contentsOf: buttonConstraints)
-
-            let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
-            currentConstraints.append(contentsOf: labelConstraints)
-
-            NSLayoutConstraint.activate(currentConstraints)
+        for hStack in [binHStack1, binHStack2, binHStack3, binHStack4, binHStack5] as [UIStackView] {
+            c += [
+                hStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+                hStack.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
         }
-        else {
-            let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: binVStack, outputLabel: outputLabel, screenWidth: screenWidth)
-            NSLayoutConstraint.activate(stackConstraints)
 
-            let buttonConstraints = UIHelper.setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: 2)
-            NSLayoutConstraint.activate(buttonConstraints)
+        c += [
+            outputLabel.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
+            outputLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topReserve)
+        ]
+        outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 
-            let labelConstraints = UIHelper.setupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, calculator: 2)
-            NSLayoutConstraint.activate(labelConstraints)
+        let singleBtns: [RoundButton] = [DIVBtn, MULTBtn, SUBBtn, PLUSBtn,
+                                         EQUALSBtn, DELBtn, XORBtn, ORBtn,
+                                         ANDBtn, NOTBtn, ONESBtn, TWOSBtn,
+                                         LSBtn, RSBtn, Btn0, Btn1, Btn00, Btn11]
+        for btn in singleBtns {
+            c += [
+                btn.widthAnchor.constraint(equalToConstant: layout.singleButtonWidth),
+                btn.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
+            btn.layer.cornerRadius = layout.cornerRadius
+            btn.titleLabel?.font = UIFont.systemFont(ofSize: layout.buttonFontSize, weight: .semibold)
         }
+
+        c += [
+            ACBtn.widthAnchor.constraint(equalToConstant: layout.doubleButtonWidth),
+            ACBtn.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+        ]
+        ACBtn.layer.cornerRadius = layout.cornerRadius
+        ACBtn.titleLabel?.font = UIFont.systemFont(ofSize: layout.buttonFontSize, weight: .semibold)
+
+        return c
     }
 
     // Load the current converted value from either of the other calculator screens

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -11,7 +11,13 @@ import UIKit
 class BinaryViewController: CalculatorViewController {
 
     //MARK: Properties
-    let binaryDefaultLabel: String = "0000 0000 0000 0000 0000 0000 0000 0000\n0000 0000 0000 0000 0000 0000 0000 0000"
+    // Number of lines formatBinaryString wraps the 64-bit string across — normally 2
+    // (32 bits each), but UIHelper can widen this on narrow windows where 2 lines
+    // would render illegibly small (see calculateLayout's compact/iPad branch).
+    // Updated from buildLayoutConstraints whenever the computed layout's own value
+    // changes, so it always matches what was actually laid out.
+    var binaryLineCount = 2
+    var binaryDefaultLabel: String { formatBinaryString(stringToConvert: "0") }
 
     @IBOutlet weak var binVStack: UIStackView!
     @IBOutlet weak var binHStack1: UIStackView!
@@ -124,6 +130,18 @@ class BinaryViewController: CalculatorViewController {
                                               targetGridHeight: targetGridHeight,
                                               isIPad: iPad)
         let (topOffset, bottomOffset) = UIHelper.verticalOffsets(safeHeight: safeHeight, layout: layout, isIPad: iPad)
+
+        // Resizing can change how many lines UIHelper wraps the binary string across
+        // (see calculateLayout's compact/iPad branch) — re-wrap whatever's currently
+        // shown to match, skipping error messages, which formatBinaryString can't parse.
+        if binaryLineCount != layout.binaryLineCount {
+            binaryLineCount = layout.binaryLineCount
+            if let current = outputLabel.text, !current.contains("Error") {
+                let digitsOnly = current.components(separatedBy: .whitespacesAndNewlines).joined()
+                updateOutputLabel(value: formatBinaryString(stringToConvert: digitsOnly))
+            }
+        }
+
         var c = [NSLayoutConstraint]()
 
         c += [
@@ -146,6 +164,10 @@ class BinaryViewController: CalculatorViewController {
             outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: topOffset)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
+        // The storyboard hardcodes numberOfLines to 2 (Binary's old fixed line count) —
+        // with more lines now possible on narrow windows, that stale value truncates
+        // the extra lines with "…" instead of showing them.
+        outputLabel.numberOfLines = layout.binaryLineCount
 
         let singleBtns: [RoundButton] = [DIVBtn, MULTBtn, SUBBtn, PLUSBtn,
                                          EQUALSBtn, DELBtn, XORBtn, ORBtn,
@@ -654,15 +676,18 @@ class BinaryViewController: CalculatorViewController {
         while (manipulatedStringToConvert.count < 64) {
             manipulatedStringToConvert = "0" + manipulatedStringToConvert
         }
-        // Split into two even halves (32 bits each) with a hard line break, rather
-        // than leaving the wrap point to the label's word-wrap — on a wide label
-        // (iPad) natural wrapping left far more digits on the first line than the
-        // second.
+        // Split into binaryLineCount even chunks (32/16/8 bits each, depending on what
+        // UIHelper decided fits) with hard line breaks, rather than leaving the wrap
+        // point to the label's word-wrap — on a wide label (iPad) natural wrapping left
+        // far more digits on the first line than the rest.
         let groups = manipulatedStringToConvert.separate(every: 4, with: " ").components(separatedBy: " ")
-        let midpoint = groups.count / 2
-        let firstHalf = groups[0..<midpoint].joined(separator: " ")
-        let secondHalf = groups[midpoint...].joined(separator: " ")
-        return firstHalf + "\n" + secondHalf
+        let groupsPerLine = max(groups.count / binaryLineCount, 1)
+        var lines: [String] = []
+        for lineStart in stride(from: 0, to: groups.count, by: groupsPerLine) {
+            let lineEnd = min(lineStart + groupsPerLine, groups.count)
+            lines.append(groups[lineStart..<lineEnd].joined(separator: " "))
+        }
+        return lines.joined(separator: "\n")
     }
 
     func formatNegativeBinaryString(stringToConvert: String) -> String {

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -97,15 +97,15 @@ class BinaryViewController: CalculatorViewController {
     override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
         let safeInsets = view.safeAreaInsets
         let safeHeight = height - safeInsets.top - safeInsets.bottom
-        let topReserve: CGFloat = 80
-        let layout = UIHelper.calculateLayout(width: width, height: safeHeight - topReserve,
-                                              rows: 5, cols: 4, labelType: .compact)
+        let layout = UIHelper.calculateLayout(width: width, height: safeHeight,
+                                              rows: 5, cols: 4, labelType: .compact,
+                                              isIPad: UIDevice.current.userInterfaceIdiom == .pad)
         var c = [NSLayoutConstraint]()
 
         c += [
             binVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
             binVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
-            binVStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: layout.labelToStackGap)
+            binVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8)
         ]
 
         for hStack in [binHStack1, binHStack2, binHStack3, binHStack4, binHStack5] as [UIStackView] {
@@ -116,9 +116,10 @@ class BinaryViewController: CalculatorViewController {
         }
 
         c += [
-            outputLabel.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            outputLabel.widthAnchor.constraint(equalToConstant: layout.outputLabelWidth),
             outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
-            outputLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topReserve)
+            outputLabel.bottomAnchor.constraint(equalTo: binVStack.topAnchor, constant: -layout.labelToStackGap),
+            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 

--- a/HexaCalc/View Controllers/BinaryViewController.swift
+++ b/HexaCalc/View Controllers/BinaryViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class BinaryViewController: CalculatorViewController {
 
     //MARK: Properties
-    let binaryDefaultLabel: String = "0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000"
+    let binaryDefaultLabel: String = "0000 0000 0000 0000 0000 0000 0000 0000\n0000 0000 0000 0000 0000 0000 0000 0000"
 
     @IBOutlet weak var binVStack: UIStackView!
     @IBOutlet weak var binHStack1: UIStackView!
@@ -62,7 +62,7 @@ class BinaryViewController: CalculatorViewController {
     override func copyTextFromLabel() -> String {
         if runningNumber == "" {
             var currentOutput = outputLabel.text ?? binaryDefaultLabel
-            currentOutput = currentOutput.replacingOccurrences(of: " ", with: "")
+            currentOutput = currentOutput.components(separatedBy: .whitespacesAndNewlines).joined()
             var end = false
             for char in currentOutput {
                 if char == "0" && !end {
@@ -97,15 +97,39 @@ class BinaryViewController: CalculatorViewController {
     override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
         let safeInsets = view.safeAreaInsets
         let safeHeight = height - safeInsets.top - safeInsets.bottom
+        let iPad = UIDevice.current.userInterfaceIdiom == .pad
+        // On iPad, match Decimal/Hexadecimal's grid height (computed with the .large
+        // label reference) so all three tabs' button grids are the same size — Binary's
+        // own .compact label is shorter, which otherwise leaves it more room and makes
+        // its grid noticeably larger than the other two tabs.
+        //
+        // The .large reference and Binary's actual .compact label use different height
+        // formulas (the compact one fits two lines to the label's width), so they can
+        // diverge — in a short/wide window the real compact label ends up taller than
+        // what the reference budgeted for. Forcing the reference's (too-large) grid
+        // height in that case over-constrains the layout (fixed-height grid + fixed-height
+        // label demand more room than the safe area has), which Auto Layout resolves by
+        // breaking a required constraint — visible as overlapping button rows. Clamping
+        // to Binary's own natural (unforced) grid height guarantees the forced height
+        // never asks for more room than actually fits.
+        let referenceLayout = UIHelper.calculateLayout(width: width, height: safeHeight,
+                                                       rows: 5, cols: 4, labelType: .large,
+                                                       isIPad: iPad)
+        let naturalLayout = UIHelper.calculateLayout(width: width, height: safeHeight,
+                                                      rows: 5, cols: 4, labelType: .compact,
+                                                      isIPad: iPad)
+        let targetGridHeight = iPad ? min(referenceLayout.vStackHeight, naturalLayout.vStackHeight) : nil
         let layout = UIHelper.calculateLayout(width: width, height: safeHeight,
                                               rows: 5, cols: 4, labelType: .compact,
-                                              isIPad: UIDevice.current.userInterfaceIdiom == .pad)
+                                              targetGridHeight: targetGridHeight,
+                                              isIPad: iPad)
+        let (topOffset, bottomOffset) = UIHelper.verticalOffsets(safeHeight: safeHeight, layout: layout, isIPad: iPad)
         var c = [NSLayoutConstraint]()
 
         c += [
             binVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
             binVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
-            binVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8)
+            binVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -bottomOffset)
         ]
 
         for hStack in [binHStack1, binHStack2, binHStack3, binHStack4, binHStack5] as [UIStackView] {
@@ -119,7 +143,7 @@ class BinaryViewController: CalculatorViewController {
             outputLabel.widthAnchor.constraint(equalToConstant: layout.outputLabelWidth),
             outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
             outputLabel.bottomAnchor.constraint(equalTo: binVStack.topAnchor, constant: -layout.labelToStackGap),
-            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
+            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: topOffset)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 
@@ -294,7 +318,7 @@ class BinaryViewController: CalculatorViewController {
             let binLeftValue = runningNumber
 
             let currLabel = outputLabel.text
-            let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+            let spacesRemoved = (currLabel?.components(separatedBy: .whitespacesAndNewlines).joined())!
             let rightShifted = String(Int(UInt64(spacesRemoved.dropLast(), radix: 2)!))
 
             stateController?.convValues.decimalVal = rightShifted
@@ -325,7 +349,7 @@ class BinaryViewController: CalculatorViewController {
         let binLeftValue = runningNumber == "" ? "0" : runningNumber
 
         let currLabel = outputLabel.text
-        let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+        let spacesRemoved = (currLabel?.components(separatedBy: .whitespacesAndNewlines).joined())!
         let castInt = UInt64(spacesRemoved, radix: 2)!
         let onesComplimentInt = ~castInt
         let onesComplimentString = String(onesComplimentInt, radix: 2)
@@ -354,7 +378,7 @@ class BinaryViewController: CalculatorViewController {
         if (stateController?.convValues.largerThan64Bits == true || outputLabel.text == binaryDefaultLabel) { return }
 
         let currLabel = outputLabel.text
-        let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+        let spacesRemoved = (currLabel?.components(separatedBy: .whitespacesAndNewlines).joined())!
         let castInt = UInt64(spacesRemoved, radix: 2)!
         let twosComplimentInt = ~castInt + 1
         let twosComplimentString = String(twosComplimentInt, radix: 2)
@@ -630,7 +654,15 @@ class BinaryViewController: CalculatorViewController {
         while (manipulatedStringToConvert.count < 64) {
             manipulatedStringToConvert = "0" + manipulatedStringToConvert
         }
-        return manipulatedStringToConvert.separate(every: 4, with: " ")
+        // Split into two even halves (32 bits each) with a hard line break, rather
+        // than leaving the wrap point to the label's word-wrap — on a wide label
+        // (iPad) natural wrapping left far more digits on the first line than the
+        // second.
+        let groups = manipulatedStringToConvert.separate(every: 4, with: " ").components(separatedBy: " ")
+        let midpoint = groups.count / 2
+        let firstHalf = groups[0..<midpoint].joined(separator: " ")
+        let secondHalf = groups[midpoint...].joined(separator: " ")
+        return firstHalf + "\n" + secondHalf
     }
 
     func formatNegativeBinaryString(stringToConvert: String) -> String {
@@ -682,7 +714,7 @@ class BinaryViewController: CalculatorViewController {
         var decCurrentVal = ""
         if (outputLabel.text?.first == "1") {
             let currLabel = outputLabel.text
-            let spacesRemoved = (currLabel?.components(separatedBy: " ").joined(separator: ""))!
+            let spacesRemoved = (currLabel?.components(separatedBy: .whitespacesAndNewlines).joined())!
             stateController?.convValues.binVal = spacesRemoved
             decCurrentVal = String(Int64(bitPattern: UInt64(spacesRemoved, radix: 2)!))
             hexCurrentVal = String(Int64(bitPattern: UInt64(spacesRemoved, radix: 2)!), radix: 16)

--- a/HexaCalc/View Controllers/CalculatorViewController.swift
+++ b/HexaCalc/View Controllers/CalculatorViewController.swift
@@ -32,6 +32,7 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     var result = ""
     var currentOperation: Operation = .NULL
     var currentConstraints: [NSLayoutConstraint] = []
+    private var lastLayoutSize: CGSize = .zero
     var currentlyRecognizingDoubleTap = false
     var calculationHistory: [CalculationData] = []
     var operationStack: [(leftValue: String, operation: Operation)] = []
@@ -77,6 +78,12 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     // VC-specific tinted views)
     func updateThemeColour(_ colour: UIColor) {
         fatalError("Subclass must override updateThemeColour(_:)")
+    }
+
+    // Build and return all programmatic layout constraints for the current bounds.
+    // Called from viewDidLayoutSubviews whenever the size changes.
+    func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
+        fatalError("Subclass must override buildLayoutConstraints(width:height:)")
     }
 
     var outputLabelAccessibilityIdentifier: String {
@@ -129,12 +136,20 @@ class CalculatorViewController: UIViewController, HistoryButtonHost {
     }
 
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        let size = view.bounds.size
+        guard size != lastLayoutSize, size.width > 0, size.height > 0 else { return }
+        lastLayoutSize = size
+        NSLayoutConstraint.deactivate(currentConstraints)
+        currentConstraints.removeAll()
+        currentConstraints = buildLayoutConstraints(width: size.width, height: size.height)
+        NSLayoutConstraint.activate(currentConstraints)
+        repositionHistoryButton(for: size)
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            NSLayoutConstraint.deactivate(currentConstraints)
-            currentConstraints.removeAll()
-        }
         coordinator.animate(alongsideTransition: { _ in
             self.repositionHistoryButton(for: size)
         })

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -81,37 +81,55 @@ class DecimalViewController: CalculatorViewController {
         setupCommonViewDidLoad()
     }
 
-    override func viewDidLayoutSubviews() {
-        let screenWidth = view.bounds.width
-        let screenHeight = view.bounds.height
+    override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
+        let safeInsets = view.safeAreaInsets
+        let safeHeight = height - safeInsets.top - safeInsets.bottom
+        let topReserve: CGFloat = 80
+        let layout = UIHelper.calculateLayout(width: width, height: safeHeight - topReserve,
+                                              rows: 5, cols: 4, labelType: .large)
+        var c = [NSLayoutConstraint]()
 
-        let hStacks = [decHStack1!, decHStack2!, decHStack3!, decHStack4!, decHStack5!]
-        let singleButtons = [DIVBtn!, MULTBtn!, SUBBtn!, PLUSBtn!, EQUALSBtn!, DELBtn!, DOTBtn!, SecondFunctionBtn!,
-                             ACBtn!, Btn1!, Btn2!, Btn3!, Btn4!, Btn5!, Btn6!, Btn7!, Btn8!, Btn9!]
-        let doubleButtons = [Btn0!]
+        c += [
+            decVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            decVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
+            decVStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: layout.labelToStackGap)
+        ]
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: decVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
-            currentConstraints.append(contentsOf: stackConstraints)
-
-            let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 2)
-            currentConstraints.append(contentsOf: buttonConstraints)
-
-            let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
-            currentConstraints.append(contentsOf: labelConstraints)
-
-            NSLayoutConstraint.activate(currentConstraints)
+        for hStack in [decHStack1, decHStack2, decHStack3, decHStack4, decHStack5] as [UIStackView] {
+            c += [
+                hStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+                hStack.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
         }
-        else {
-            let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: decVStack, outputLabel: outputLabel, screenWidth: screenWidth)
-            NSLayoutConstraint.activate(stackConstraints)
 
-            let buttonConstraints = UIHelper.setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: 2)
-            NSLayoutConstraint.activate(buttonConstraints)
+        c += [
+            outputLabel.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
+            outputLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topReserve)
+        ]
+        outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 
-            let labelConstraints = UIHelper.setupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, calculator: 1)
-            NSLayoutConstraint.activate(labelConstraints)
+        let singleBtns: [RoundButton] = [DIVBtn, MULTBtn, SUBBtn, PLUSBtn,
+                                         EQUALSBtn, DELBtn, DOTBtn, SecondFunctionBtn,
+                                         ACBtn, Btn1, Btn2, Btn3,
+                                         Btn4, Btn5, Btn6, Btn7, Btn8, Btn9]
+        for btn in singleBtns {
+            c += [
+                btn.widthAnchor.constraint(equalToConstant: layout.singleButtonWidth),
+                btn.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
+            btn.layer.cornerRadius = layout.cornerRadius
+            btn.titleLabel?.font = UIFont.systemFont(ofSize: layout.buttonFontSize, weight: .semibold)
         }
+
+        c += [
+            Btn0.widthAnchor.constraint(equalToConstant: layout.doubleButtonWidth),
+            Btn0.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+        ]
+        Btn0.layer.cornerRadius = layout.cornerRadius
+        Btn0.titleLabel?.font = UIFont.systemFont(ofSize: layout.buttonFontSize, weight: .semibold)
+
+        return c
     }
 
     // Load the current converted value from either of the other calculator screens

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -84,15 +84,17 @@ class DecimalViewController: CalculatorViewController {
     override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
         let safeInsets = view.safeAreaInsets
         let safeHeight = height - safeInsets.top - safeInsets.bottom
+        let iPad = UIDevice.current.userInterfaceIdiom == .pad
         let layout = UIHelper.calculateLayout(width: width, height: safeHeight,
                                               rows: 5, cols: 4, labelType: .large,
-                                              isIPad: UIDevice.current.userInterfaceIdiom == .pad)
+                                              isIPad: iPad)
+        let (topOffset, bottomOffset) = UIHelper.verticalOffsets(safeHeight: safeHeight, layout: layout, isIPad: iPad)
         var c = [NSLayoutConstraint]()
 
         c += [
             decVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
             decVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
-            decVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8)
+            decVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -bottomOffset)
         ]
 
         for hStack in [decHStack1, decHStack2, decHStack3, decHStack4, decHStack5] as [UIStackView] {
@@ -106,7 +108,7 @@ class DecimalViewController: CalculatorViewController {
             outputLabel.widthAnchor.constraint(equalToConstant: layout.outputLabelWidth),
             outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
             outputLabel.bottomAnchor.constraint(equalTo: decVStack.topAnchor, constant: -layout.labelToStackGap),
-            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
+            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: topOffset)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 

--- a/HexaCalc/View Controllers/DecimalViewController.swift
+++ b/HexaCalc/View Controllers/DecimalViewController.swift
@@ -84,15 +84,15 @@ class DecimalViewController: CalculatorViewController {
     override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
         let safeInsets = view.safeAreaInsets
         let safeHeight = height - safeInsets.top - safeInsets.bottom
-        let topReserve: CGFloat = 80
-        let layout = UIHelper.calculateLayout(width: width, height: safeHeight - topReserve,
-                                              rows: 5, cols: 4, labelType: .large)
+        let layout = UIHelper.calculateLayout(width: width, height: safeHeight,
+                                              rows: 5, cols: 4, labelType: .large,
+                                              isIPad: UIDevice.current.userInterfaceIdiom == .pad)
         var c = [NSLayoutConstraint]()
 
         c += [
             decVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
             decVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
-            decVStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: layout.labelToStackGap)
+            decVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8)
         ]
 
         for hStack in [decHStack1, decHStack2, decHStack3, decHStack4, decHStack5] as [UIStackView] {
@@ -103,9 +103,10 @@ class DecimalViewController: CalculatorViewController {
         }
 
         c += [
-            outputLabel.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            outputLabel.widthAnchor.constraint(equalToConstant: layout.outputLabelWidth),
             outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
-            outputLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topReserve)
+            outputLabel.bottomAnchor.constraint(equalTo: decVStack.topAnchor, constant: -layout.labelToStackGap),
+            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -98,38 +98,58 @@ class HexadecimalViewController: CalculatorViewController {
         }
     }
 
-    override func viewDidLayoutSubviews() {
-        let screenWidth = view.bounds.width
-        let screenHeight = view.bounds.height
+    override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
+        let safeInsets = view.safeAreaInsets
+        let safeHeight = height - safeInsets.top - safeInsets.bottom
+        let topReserve: CGFloat = 80
+        let layout = UIHelper.calculateLayout(width: width, height: safeHeight - topReserve,
+                                              rows: 6, cols: 5, labelType: .large)
+        var c = [NSLayoutConstraint]()
 
-        let hStacks = [hexHStack1!, hexHStack2!, hexHStack3!, hexHStack4!, hexHStack5!, hexHStack6!]
-        let singleButtons = [XORBtn!, ORBtn!, ANDBtn!, NOTBtn!, DIVBtn!, MULTBtn!, SUBBtn!, PLUSBtn!, EQUALSBtn!,
-                             Btn0!, Btn1!, Btn2!, Btn3!, Btn4!, Btn5!, Btn6!, Btn7!, Btn8!, Btn9!,
-                             ABtn!, BBtn!, CBtn!, DBtn!, EBtn!, FBtn!, SecondFunctionBtn!]
-        let doubleButtons = [ACBtn!, DELBtn!]
+        c += [
+            hexVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            hexVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
+            hexVStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: layout.labelToStackGap)
+        ]
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            let stackConstraints = UIHelper.iPadSetupStackConstraints(hStacks: hStacks, vStack: hexVStack, outputLabel: outputLabel, screenWidth: screenWidth, screenHeight: screenHeight)
-            currentConstraints.append(contentsOf: stackConstraints)
-
-            let buttonConstraints = UIHelper.iPadSetupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
-            currentConstraints.append(contentsOf: buttonConstraints)
-
-            let labelConstraints = UIHelper.iPadSetupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, screenHeight: screenHeight, calculator: 1)
-            currentConstraints.append(contentsOf: labelConstraints)
-
-            NSLayoutConstraint.activate(currentConstraints)
+        for hStack in [hexHStack1, hexHStack2, hexHStack3, hexHStack4, hexHStack5, hexHStack6] as [UIStackView] {
+            c += [
+                hStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+                hStack.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
         }
-        else {
-            let stackConstraints = UIHelper.setupStackConstraints(hStacks: hStacks, vStack: hexVStack, outputLabel: outputLabel, screenWidth: screenWidth)
-            NSLayoutConstraint.activate(stackConstraints)
 
-            let buttonConstraints = UIHelper.setupButtonConstraints(singleButtons: singleButtons, doubleButtons: doubleButtons, screenWidth: screenWidth, calculator: 1)
-            NSLayoutConstraint.activate(buttonConstraints)
+        c += [
+            outputLabel.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
+            outputLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topReserve)
+        ]
+        outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 
-            let labelConstraints = UIHelper.setupLabelConstraints(label: outputLabel!, screenWidth: screenWidth, calculator: 1)
-            NSLayoutConstraint.activate(labelConstraints)
+        let singleBtns: [RoundButton] = [XORBtn, ORBtn, ANDBtn, NOTBtn, DIVBtn,
+                                         MULTBtn, Btn8, Btn9, ABtn, BBtn,
+                                         SUBBtn, Btn4, Btn5, Btn6, Btn7,
+                                         PLUSBtn, Btn0, Btn1, Btn2, Btn3,
+                                         EQUALSBtn, CBtn, DBtn, EBtn, FBtn, SecondFunctionBtn]
+        for btn in singleBtns {
+            c += [
+                btn.widthAnchor.constraint(equalToConstant: layout.singleButtonWidth),
+                btn.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
+            btn.layer.cornerRadius = layout.cornerRadius
+            btn.titleLabel?.font = UIFont.systemFont(ofSize: layout.buttonFontSize, weight: .semibold)
         }
+
+        for btn in [ACBtn, DELBtn] as [RoundButton] {
+            c += [
+                btn.widthAnchor.constraint(equalToConstant: layout.doubleButtonWidth),
+                btn.heightAnchor.constraint(equalToConstant: layout.hStackHeight)
+            ]
+            btn.layer.cornerRadius = layout.cornerRadius
+            btn.titleLabel?.font = UIFont.systemFont(ofSize: layout.buttonFontSize, weight: .semibold)
+        }
+
+        return c
     }
 
     // Load the current converted value from either of the other calculator screens

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -101,15 +101,22 @@ class HexadecimalViewController: CalculatorViewController {
     override func buildLayoutConstraints(width: CGFloat, height: CGFloat) -> [NSLayoutConstraint] {
         let safeInsets = view.safeAreaInsets
         let safeHeight = height - safeInsets.top - safeInsets.bottom
-        let topReserve: CGFloat = 80
-        let layout = UIHelper.calculateLayout(width: width, height: safeHeight - topReserve,
-                                              rows: 6, cols: 5, labelType: .large)
+        let iPad = UIDevice.current.userInterfaceIdiom == .pad
+        // Use the grid height that Binary/Decimal naturally produce so all three tabs
+        // share the same total grid area for visual consistency when switching tabs.
+        let referenceLayout = UIHelper.calculateLayout(width: width, height: safeHeight,
+                                                       rows: 5, cols: 4, labelType: .large,
+                                                       isIPad: iPad)
+        let layout = UIHelper.calculateLayout(width: width, height: safeHeight,
+                                              rows: 6, cols: 5, labelType: .large,
+                                              targetGridHeight: referenceLayout.vStackHeight,
+                                              isIPad: iPad)
         var c = [NSLayoutConstraint]()
 
         c += [
             hexVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
             hexVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
-            hexVStack.topAnchor.constraint(equalTo: outputLabel.bottomAnchor, constant: layout.labelToStackGap)
+            hexVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8)
         ]
 
         for hStack in [hexHStack1, hexHStack2, hexHStack3, hexHStack4, hexHStack5, hexHStack6] as [UIStackView] {
@@ -120,9 +127,10 @@ class HexadecimalViewController: CalculatorViewController {
         }
 
         c += [
-            outputLabel.widthAnchor.constraint(equalToConstant: layout.stackWidth),
+            outputLabel.widthAnchor.constraint(equalToConstant: layout.outputLabelWidth),
             outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
-            outputLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topReserve)
+            outputLabel.bottomAnchor.constraint(equalTo: hexVStack.topAnchor, constant: -layout.labelToStackGap),
+            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 

--- a/HexaCalc/View Controllers/HexadecimalViewController.swift
+++ b/HexaCalc/View Controllers/HexadecimalViewController.swift
@@ -111,12 +111,13 @@ class HexadecimalViewController: CalculatorViewController {
                                               rows: 6, cols: 5, labelType: .large,
                                               targetGridHeight: referenceLayout.vStackHeight,
                                               isIPad: iPad)
+        let (topOffset, bottomOffset) = UIHelper.verticalOffsets(safeHeight: safeHeight, layout: layout, isIPad: iPad)
         var c = [NSLayoutConstraint]()
 
         c += [
             hexVStack.widthAnchor.constraint(equalToConstant: layout.stackWidth),
             hexVStack.heightAnchor.constraint(equalToConstant: layout.vStackHeight),
-            hexVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8)
+            hexVStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -bottomOffset)
         ]
 
         for hStack in [hexHStack1, hexHStack2, hexHStack3, hexHStack4, hexHStack5, hexHStack6] as [UIStackView] {
@@ -130,7 +131,7 @@ class HexadecimalViewController: CalculatorViewController {
             outputLabel.widthAnchor.constraint(equalToConstant: layout.outputLabelWidth),
             outputLabel.heightAnchor.constraint(equalToConstant: layout.labelHeight),
             outputLabel.bottomAnchor.constraint(equalTo: hexVStack.topAnchor, constant: -layout.labelToStackGap),
-            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 8)
+            outputLabel.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: topOffset)
         ]
         outputLabel.font = UIFont(name: "Avenir Next", size: layout.labelFontSize)
 

--- a/HexaCalcUITests/UITestHelper.swift
+++ b/HexaCalcUITests/UITestHelper.swift
@@ -185,7 +185,11 @@ class UITestHelper {
         while (manipulatedStringToConvert.count < 64){
             manipulatedStringToConvert = "0" + manipulatedStringToConvert
         }
-        return manipulatedStringToConvert.separate(every: 4, with: " ")
+        let groups = manipulatedStringToConvert.separate(every: 4, with: " ").components(separatedBy: " ")
+        let midpoint = groups.count / 2
+        let firstHalf = groups[0..<midpoint].joined(separator: " ")
+        let secondHalf = groups[midpoint...].joined(separator: " ")
+        return firstHalf + "\n" + secondHalf
     }
     
     static func formatDecimalString(stringToConvert: String) -> String {


### PR DESCRIPTION
## Summary

- Replaces 6 static `UIHelper` layout functions with a single `calculateLayout()` formula that works for any window size
- Adds abstract `buildLayoutConstraints(width:height:)` override in `CalculatorViewController`, called from `viewDidLayoutSubviews` with a `lastLayoutSize` guard to prevent infinite loops
- Buttons always fill the full available width; height is independently capped by vertical space so landscape iPad stays proportional
- Clears 80pt at the top of the safe area so the history button is never obscured
- Storyboard cleaned up: removed 6 obsolete bottom/top-priority constraints (kept centerX constraints for horizontal centering)
- Supports continuous resizing including iPad Stage Manager free-form windows and device rotation

## Test plan

- [ ] iPhone SE — portrait and landscape: buttons fill width, label clears history button
- [ ] iPhone (standard) — portrait and landscape
- [ ] iPad — portrait and landscape: buttons fill width, height scales to fit rows
- [ ] iPad Stage Manager — drag window to various sizes and confirm live resize works
- [ ] Rotate device mid-session: layout updates without constraint conflicts
- [ ] All three calculator tabs (Hex, Binary, Decimal) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)