### PR TITLE
Add liquid glass button effect (opt-in setting)

### DIFF
--- a/HexaCalc/Model/StateController.swift
+++ b/HexaCalc/Model/StateController.swift
@@ -22,6 +22,7 @@ struct convVals{
     var pasteActionIndex: Int32 = 1
     var historyButtonViewIndex: Int32 = 0
     var historyEnabled: Bool = true
+    var liquidGlassButtons: Bool = false
     // Acts as a binary flag (1 bit for each calculator)
     var clearLocalHistory: Int32 = 0
     var defaultTabIndex: Int32 = 3

--- a/HexaCalc/Model/TelemetryManager.swift
+++ b/HexaCalc/Model/TelemetryManager.swift
@@ -111,6 +111,7 @@ enum TelemetrySettingsAction: String {
     // Customization actions
     case Colour = "colourChanged"
     case TextColour = "setCalculatorTextColourSwitchPressed"
+    case LiquidGlass = "liquidGlassButtonsSwitchPressed"
     // Calculation history actions
     case History = "historyButtonViewChanged"
     case ClearHistory = "clearLocalHistory"

--- a/HexaCalc/Model/UserPreferences.swift
+++ b/HexaCalc/Model/UserPreferences.swift
@@ -21,7 +21,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
     
     //Prepares and instance of a class for use
     init(colour: UIColor, colourNum: Int64, hexTabState: Bool, binTabState: Bool, decTabState: Bool, setCalculatorTextColour: Bool, copyActionIndex: Int32, pasteActionIndex: Int32,
-         historyButtonViewIndex: Int32, defaultTabIndex: Int32, historyEnabled: Bool = true, telemetryEnabled: Bool = true) {
+         historyButtonViewIndex: Int32, defaultTabIndex: Int32, historyEnabled: Bool = true, telemetryEnabled: Bool = true, liquidGlassButtons: Bool = false) {
         //Initialize stored properties.
         self.colour = colour
         self.colourNum = colourNum
@@ -35,6 +35,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         self.defaultTabIndex = defaultTabIndex
         self.historyEnabled = historyEnabled
         self.telemetryEnabled = telemetryEnabled
+        self.liquidGlassButtons = liquidGlassButtons
     }
     
     //MARK: Properties
@@ -51,6 +52,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
     var defaultTabIndex: Int32
     var historyEnabled: Bool
     var telemetryEnabled: Bool
+    var liquidGlassButtons: Bool
     
     //MARK: Archiving Paths
     
@@ -73,6 +75,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         static let defaultTabIndex = "defaultTabIndex"
         static let historyEnabled = "historyEnabled"
         static let telemetryEnabled = "telemetryEnabled"
+        static let liquidGlassButtons = "liquidGlassButtons"
     }
     
     //MARK: NSCoding
@@ -90,6 +93,7 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
         aCoder.encode(defaultTabIndex, forKey: PropertyKey.defaultTabIndex)
         aCoder.encode(historyEnabled, forKey: PropertyKey.historyEnabled)
         aCoder.encode(telemetryEnabled, forKey: PropertyKey.telemetryEnabled)
+        aCoder.encode(liquidGlassButtons, forKey: PropertyKey.liquidGlassButtons)
     }
     
     required convenience init?(coder aDecoder: NSCoder) {
@@ -130,6 +134,14 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
             telemetryEnabled = true
         }
 
+        // Default false for users upgrading from a version before liquidGlassButtons was added
+        let liquidGlassButtons: Bool
+        if aDecoder.containsValue(forKey: PropertyKey.liquidGlassButtons) {
+            liquidGlassButtons = aDecoder.decodeBool(forKey: PropertyKey.liquidGlassButtons)
+        } else {
+            liquidGlassButtons = false
+        }
+
         //Must call designated initializer
         self.init(
             colour: colour,
@@ -143,7 +155,8 @@ class UserPreferences : NSObject, NSCoding, NSSecureCoding {
             historyButtonViewIndex: historyButtonViewIndex,
             defaultTabIndex: defaultTabIndex,
             historyEnabled: historyEnabled,
-            telemetryEnabled: telemetryEnabled
+            telemetryEnabled: telemetryEnabled,
+            liquidGlassButtons: liquidGlassButtons
         )
     }
     

--- a/HexaCalc/View Controllers/HexaCalcTabBarController.swift
+++ b/HexaCalc/View Controllers/HexaCalcTabBarController.swift
@@ -39,7 +39,9 @@ class HexaCalcTabBarController: UITabBarController, StateControllerProtocol {
         stateController?.convValues.historyButtonViewIndex = savedPreferences.historyButtonViewIndex
         stateController?.convValues.historyEnabled = savedPreferences.historyEnabled
         stateController?.convValues.defaultTabIndex = savedPreferences.defaultTabIndex
+        stateController?.convValues.liquidGlassButtons = savedPreferences.liquidGlassButtons
 
+        RoundButton.liquidGlassEnabled = savedPreferences.liquidGlassButtons
         TelemetryManager.sharedTelemetryManager.userTelemetryEnabled = savedPreferences.telemetryEnabled
 
         // Remove disabled tabs before any child VC loads (avoids mutating viewControllers

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -590,6 +590,12 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         stateController?.convValues.liquidGlassButtons = sender.isOn
         RoundButton.liquidGlassEnabled = sender.isOn
         self.preferences = userPreferences
+
+        telemetryManager.sendSettingsSignal(
+            section: TelemetrySettingsSection.Customization,
+            action: TelemetrySettingsAction.LiquidGlass,
+            parameters: ["switchState": "\(sender.isOn)"]
+        )
     }
 
     @objc func telemetrySwitchChanged(_ sender: UISwitch) {

--- a/HexaCalc/View Controllers/SettingsViewController.swift
+++ b/HexaCalc/View Controllers/SettingsViewController.swift
@@ -22,7 +22,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                           "About the app",
                           "Support",
                           "Privacy" ]
-    let rowsPerSection = [4, 2, 2, 3, 4, 3, 1]
+    let rowsPerSection = [4, 2, 3, 3, 4, 3, 1]
     
     let supportURLs = [ "https://anthony55hopkins.wixsite.com/hexacalc/privacy-policy",
                         "https://anthony55hopkins.wixsite.com/hexacalc/terms-conditions" ]
@@ -53,6 +53,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "DecimalSwitch")
         table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "HistorySwitch")
         table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "TelemetrySwitch")
+        table.register(SwitchTableViewCell.nib(), forCellReuseIdentifier: "LiquidGlassSwitch")
         table.register(SelectionSummaryTableViewCell.self, forCellReuseIdentifier: "ColourSelection")
         table.register(SelectionSummaryTableViewCell.self, forCellReuseIdentifier: "CopyActionSelection")
         table.register(SelectionSummaryTableViewCell.self, forCellReuseIdentifier: "PasteActionSelection")
@@ -232,6 +233,14 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                 cell.configure(isOn: self.preferences.setCalculatorTextColour, colour: preferences.colour)
                 cell.textLabel?.text = "Set Calculator Text Colour"
                 cell.self.cellSwitch.addTarget(self, action: #selector(self.setCalculatorTextColourSwitchPressed), for: .touchUpInside)
+                return cell
+            }
+            // Liquid glass buttons toggle
+            else if indexPath.row == 2 {
+                let cell = self.tableView.dequeueReusableCell(withIdentifier: "LiquidGlassSwitch", for: indexPath) as! SwitchTableViewCell
+                cell.configure(isOn: self.preferences.liquidGlassButtons, colour: preferences.colour)
+                cell.textLabel?.text = "Liquid Glass Buttons"
+                cell.cellSwitch.addTarget(self, action: #selector(self.liquidGlassSwitchPressed), for: .touchUpInside)
                 return cell
             }
             // Select colour preference
@@ -471,7 +480,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
-                                              historyEnabled: preferences.historyEnabled)
+                                              historyEnabled: preferences.historyEnabled, liquidGlassButtons: preferences.liquidGlassButtons)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         (tabBarController as? HexaCalcTabBarController)?.setTab(0, enabled: sender.isOn)
         self.preferences = userPreferences
@@ -491,7 +500,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
-                                              historyEnabled: preferences.historyEnabled)
+                                              historyEnabled: preferences.historyEnabled, liquidGlassButtons: preferences.liquidGlassButtons)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         (tabBarController as? HexaCalcTabBarController)?.setTab(1, enabled: sender.isOn)
         self.preferences = userPreferences
@@ -511,7 +520,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
-                                              historyEnabled: preferences.historyEnabled)
+                                              historyEnabled: preferences.historyEnabled, liquidGlassButtons: preferences.liquidGlassButtons)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         (tabBarController as? HexaCalcTabBarController)?.setTab(2, enabled: sender.isOn)
         self.preferences = userPreferences
@@ -532,7 +541,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: sender.isOn,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
-                                              historyEnabled: preferences.historyEnabled)
+                                              historyEnabled: preferences.historyEnabled, liquidGlassButtons: preferences.liquidGlassButtons)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         stateController?.convValues.setCalculatorTextColour = sender.isOn
         self.preferences = userPreferences
@@ -552,7 +561,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                                               setCalculatorTextColour: preferences.setCalculatorTextColour,
                                               copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
                                               historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
-                                              historyEnabled: sender.isOn)
+                                              historyEnabled: sender.isOn, liquidGlassButtons: preferences.liquidGlassButtons)
         DataPersistence.savePreferences(userPreferences: userPreferences)
         stateController?.convValues.historyEnabled = sender.isOn
         if !sender.isOn {
@@ -568,6 +577,19 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                 "switchState": "\(sender.isOn)"
             ]
         )
+    }
+
+    @IBAction func liquidGlassSwitchPressed(_ sender: UISwitch) {
+        let userPreferences = UserPreferences(colour: preferences.colour, colourNum: (stateController?.convValues.colourNum)!,
+                                              hexTabState: preferences.hexTabState, binTabState: preferences.binTabState, decTabState: preferences.decTabState,
+                                              setCalculatorTextColour: preferences.setCalculatorTextColour,
+                                              copyActionIndex: preferences.copyActionIndex, pasteActionIndex: preferences.pasteActionIndex,
+                                              historyButtonViewIndex: preferences.historyButtonViewIndex, defaultTabIndex: preferences.defaultTabIndex,
+                                              historyEnabled: preferences.historyEnabled, liquidGlassButtons: sender.isOn)
+        DataPersistence.savePreferences(userPreferences: userPreferences)
+        stateController?.convValues.liquidGlassButtons = sender.isOn
+        RoundButton.liquidGlassEnabled = sender.isOn
+        self.preferences = userPreferences
     }
 
     @objc func telemetrySwitchChanged(_ sender: UISwitch) {

--- a/HexaCalc/Views/RoundButton.swift
+++ b/HexaCalc/Views/RoundButton.swift
@@ -11,18 +11,88 @@ import UIKit
 @IBDesignable
 class RoundButton: UIButton {
 
-    @IBInspectable var roundButton:Bool = false {
+    // Set to true at launch via HexaCalcTabBarController when the user preference is on.
+    static var liquidGlassEnabled = false
+
+    @IBInspectable var roundButton: Bool = false {
         didSet {
             if roundButton {
                 layer.cornerRadius = frame.height / 2
             }
         }
     }
-    
+
+    // MARK: - Liquid glass layers
+
+    private var glassSpecularLayer: CAGradientLayer?
+    private var glassBorderLayer: CALayer?
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard layer.cornerRadius > 0 else { return }
+        if Self.liquidGlassEnabled {
+            applyLiquidGlass()
+        } else {
+            removeLiquidGlass()
+        }
+    }
+
+    // MARK: - Glass effect
+
+    private func applyLiquidGlass() {
+        let radius = layer.cornerRadius
+
+        if glassSpecularLayer == nil {
+            let specular = CAGradientLayer()
+            specular.startPoint = CGPoint(x: 0.5, y: 0.0)
+            specular.endPoint = CGPoint(x: 0.5, y: 1.0)
+            layer.insertSublayer(specular, at: 0)
+            glassSpecularLayer = specular
+        }
+        if glassBorderLayer == nil {
+            let border = CALayer()
+            border.masksToBounds = true
+            layer.addSublayer(border)
+            glassBorderLayer = border
+        }
+
+        glassSpecularLayer?.frame = bounds
+        glassSpecularLayer?.cornerRadius = radius
+        glassSpecularLayer?.masksToBounds = true
+        glassSpecularLayer?.colors = [
+            UIColor.white.withAlphaComponent(0.42).cgColor,
+            UIColor.white.withAlphaComponent(0.15).cgColor,
+            UIColor.white.withAlphaComponent(0.0).cgColor,
+        ]
+        glassSpecularLayer?.locations = [0.0, 0.38, 0.65]
+
+        glassBorderLayer?.frame = bounds
+        glassBorderLayer?.cornerRadius = radius
+        glassBorderLayer?.borderWidth = 1.0
+        glassBorderLayer?.borderColor = UIColor.white.withAlphaComponent(0.30).cgColor
+
+        // Shadow requires masksToBounds = false; corner rounding on the layer itself still works.
+        layer.masksToBounds = false
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.28
+        layer.shadowRadius = 4.0
+        layer.shadowOffset = CGSize(width: 0, height: 3)
+    }
+
+    private func removeLiquidGlass() {
+        guard glassSpecularLayer != nil || glassBorderLayer != nil else { return }
+        glassSpecularLayer?.removeFromSuperlayer()
+        glassSpecularLayer = nil
+        glassBorderLayer?.removeFromSuperlayer()
+        glassBorderLayer = nil
+        layer.shadowOpacity = 0
+    }
+
     override func prepareForInterfaceBuilder() {
         if roundButton {
             layer.cornerRadius = frame.height / 2
         }
     }
-
 }


### PR DESCRIPTION
## Summary

- Adds a CALayer-based liquid glass effect to all `RoundButton` instances: a top-to-bottom specular highlight gradient, a glassy edge border, and a depth drop shadow
- Gated behind a new **"Liquid Glass Buttons"** toggle in Settings → Customization, defaulting to **off** so no existing users are affected
- Persisted via `UserPreferences` with a backward-compatible decode fallback; propagated through `StateController` and set as a static flag on `RoundButton` at launch
- Telemetry wired up via `TelemetryDeck` (`Settings.Customization.liquidGlassButtonsSwitchPressed` with `switchState` parameter) to track discovery and adoption

## Test plan

- [x] Fresh install: confirm liquid glass is off by default, all buttons look unchanged
- [x] Enable "Liquid Glass Buttons" in Settings → Customization, switch to any calculator tab and confirm specular/border/shadow effects appear on all buttons
- [x] Toggle off and confirm effects are removed cleanly on next layout pass
- [x] Rotate device while effect is on to confirm layers resize correctly with no artefacts
- [x] Verify theme colour operator buttons (green, red, etc.) still show colour correctly under the glass overlay
- [x] Verify other settings toggles (tab visibility, text colour, history, telemetry) still persist correctly after the new row is present
- [x] Confirm telemetry fires in TelemetryDeck when toggling the switch on and off

🤖 Generated with [Claude Code](https://claude.com/claude-code)